### PR TITLE
feat: AckCoordinator centralized checkpoint lifecycle management

### DIFF
--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -2,53 +2,113 @@
 
 ## Engine Lifecycle
 
-1. **Build** – Configuration is parsed, adapter registrations are resolved, and each source/sink is configured with the root `context.Context`. No goroutines are launched at this stage.
-2. **Start** – `Runner.Start(ctx)` starts the source. Frames emitted by the source run through the transformer chain and into sinks synchronously using the same lineage context.
-3. **Stop** – Cancellation of the root context shuts down the pipeline. Sinks receive `Close(ctx)` first, followed by transformers, then the source. The transport server drains outstanding RPCs while the runner exits.
+1. **Build** – Configuration is parsed, adapter registrations are resolved, and each source/sink is configured with the root `context.Context`. The `AckCoordinator` is created and wired into the `Runner`. No goroutines are launched at this stage.
+2. **Start** – `Runner.Start(ctx)` starts the source. Frames emitted by the source run through the transformer chain and into sinks. `AckAware` sinks (Kafka, S3) publish asynchronously and call back through the coordinator when delivery is confirmed.
+3. **Stop** – Cancellation of the root context shuts down the pipeline. Sinks receive `Close(ctx)` first, followed by transformers, then the source. The transport server drains outstanding RPCs while the runner exits. Outstanding barriers are abandoned (no commit).
 
 ## Context Propagation
 
-- The source supplies a context for each emitted frame. Transformers and sinks *must* honour deadlines and cancellations on that context.
+- The source supplies a context for each emitted frame. Transformers and sinks _must_ honour deadlines and cancellations on that context.
 - Retries wrap the frame context with `context.WithTimeout`, ensuring cancellation cascades downstream.
 - Shutdown is graceful: once the root context is cancelled, blocking operations unblock and return errors.
 
 ## Backpressure Semantics
 
 - Source drivers use bounded semaphores (`Controller`) to cap in-flight frames. If the pipeline stalls, sources block before `emit`.
-- Sinks publish synchronously; if their internal queues saturate they block until space is freed or context is cancelled.
-- Ack handling (`ackTracker`) serialises callbacks to guarantee offsets are committed exactly once and never lost when queues overflow.
+- `AckAware` sinks (Kafka, S3) publish non-blocking; backpressure propagates through the coordinator's outstanding barrier count.
+- Synchronous sinks (stdout) complete inline — the barrier receives its `Complete()` call immediately after `Publish` returns.
 
 ## Delivery Guarantees
 
 - Default behaviour: **at-least-once** delivery. Frames are retried until sinks confirm success.
 - **At-most-once** is not provided; offsets are never committed before processing completes.
 - **Exactly-once** is not guaranteed. Users can approach it with idempotent sinks and E2E mode.
-- **E2E Mode** defers offset commits until sinks acknowledge, ensuring upstream brokers are only advanced after complete success.
+- **E2E Mode** defers offset commits until **all** sinks acknowledge via the `AckCoordinator` barrier, ensuring upstream brokers are only advanced after complete success.
 
-## Flow Overview
+## AckCoordinator
+
+The `AckCoordinator` is the **sole commit authority** in the pipeline. No component ever commits a checkpoint directly — all commits flow through the coordinator.
+
+### Design
+
+Inspired by the Linux kernel's `kref` refcounting pattern and Kafka's group-coordinator protocol:
+
+- **Barrier** — a refcounted completion token created per source frame. The reference count equals `len(derivedFrames) × ackAwareSinks + 1` (the `+1` accounts for synchronous sinks).
+- **Tri-state CAS** — each barrier transitions through exactly one of three terminal states: `Live → Committed` or `Live → Aborted`. A single `CompareAndSwap` arbitrates the race between `release()` and `Abort()`.
+- **Pointer-safe removal** — `removeBarrier` compares the map entry's pointer identity before deleting, preventing a successor barrier from being accidentally clobbered by its predecessor's cleanup.
+
+### Barrier State Machine
+
+```mermaid
+stateDiagram-v2
+  [*] --> Live : Barrier(tok, refs)
+  Live --> Committed : refs ≤ 0 (CAS succeeds)
+  Live --> Aborted : Abort() CAS succeeds
+  Committed --> [*] : commit(tok) → source
+  Aborted --> [*] : removeBarrier (no commit)
+```
+
+### Data Flow
 
 ```mermaid
 flowchart LR
   kIn["Kafka Broker\n(input)"]
   kOut["Kafka Broker\n(output)"]
+  s3["S3 Bucket"]
 
   subgraph Engine
     direction LR
     src["Source Adapter\n(sarama)"]
     run["Pipeline Runner\n(transform chain)"]
-    snk["Sink Adapter(s)\n(kafka/stdout)"]
-    ack["Ack Tracker"]
+    coord["AckCoordinator\n(barrier map)"]
+    snk_k["Kafka Sink\n(AckAware)"]
+    snk_s3["S3 Sink\n(AckAware)"]
+    snk_out["Stdout Sink\n(sync)"]
   end
 
   kIn --> src
   src --> run
-  run -- gRPC --> xform["Transformer Process\n(gRPC)"]
-  xform -- events --> run
-  run --> snk
-  snk --> kOut
-  snk -- ack --> ack
-  ack -- commit --> src
-  run -. stdout .-> snk
+  run -- "gRPC" --> xform["Transformer\n(gRPC)"]
+  xform -- "events" --> run
+
+  run -- "Barrier(tok, refs)" --> coord
+  run --> snk_k
+  run --> snk_s3
+  run -.-> snk_out
+
+  snk_k -- "Ack(tok)" --> coord
+  snk_s3 -- "Ack(tok)" --> coord
+  snk_out -- "Complete()" --> coord
+
+  snk_k --> kOut
+  snk_s3 --> s3
+
+  coord -- "commit → Subscribe" --> src
+```
+
+### Coordinator Sequence
+
+```mermaid
+sequenceDiagram
+  participant Source
+  participant Runner
+  participant Coordinator as AckCoordinator
+  participant KafkaSink as Kafka Sink (AckAware)
+  participant S3Sink as S3 Sink (AckAware)
+
+  Source->>Runner: emit(ctx, frame)
+  Runner->>Runner: run transform chain
+  Runner->>Coordinator: Barrier(tok, refs=3)
+  Runner->>KafkaSink: Publish(frame₁)
+  Runner->>S3Sink: Publish(frame₁)
+  Note over KafkaSink: non-blocking enqueue
+
+  KafkaSink-->>Coordinator: Ack(tok) [on producer success]
+  S3Sink-->>Coordinator: Ack(tok) [on batch upload]
+  Runner->>Coordinator: Complete() [sync sinks done]
+
+  Note over Coordinator: refs=0, CAS Live→Committed
+  Coordinator->>Source: Subscribe callback → commit offset
 ```
 
 ### Transformer RPC Modes
@@ -77,17 +137,18 @@ sequenceDiagram
   StreamClient-->>Runner: events / control
 ```
 
-### Ack & Commit Loop
+### Error & Abort Flow
 
 ```mermaid
 sequenceDiagram
-  participant Sink
-  participant AckTracker
-  participant Source as Source Adapter
-  participant Kafka as Kafka Broker
+  participant Runner
+  participant Coordinator as AckCoordinator
+  participant DeadLetter as DeadLetterFn
 
-  Sink->>AckTracker: emit ack(frame checkpoint)
-  AckTracker->>Source: callback(ctx, checkpoint)
-  Source->>Kafka: Commit offset
-  Kafka-->>Source: Commit success
+  Runner->>Coordinator: Barrier(tok, refs=2)
+  Runner->>Runner: publishAll fails
+  Runner->>Coordinator: barrier.Abort()
+  Note over Coordinator: CAS Live→Aborted, no commit
+  Runner->>Coordinator: Fail(stage, frame, err)
+  Coordinator->>DeadLetter: fn(stage, frame, err)
 ```

--- a/docs/specs/e2e-semantics.md
+++ b/docs/specs/e2e-semantics.md
@@ -1,12 +1,65 @@
 # E2E Offset Commit Semantics
 
-| Scenario | Current Behaviour | Target Policy |
-|----------|-------------------|---------------|
-| Transform OK → Sink OK | Offsets committed after sink acknowledgement. | Keep. |
-| Transform returns error | Runner retries per stage policy, then acknowledges after exhaustion (no commit). | Commit only after sink success; retry budget remains. |
-| Sink returns error | Runner propagates error; source stops; offset not committed. | Retry sink publish, send to DLQ if configured, commit only after success. |
-| Transformer DROP | Frame acknowledged immediately; offset committed. | Keep. |
-| Context cancellation | No commit; outstanding frames dropped. | Keep. |
+## Commit Authority
 
-Tests under `internal/e2e` capture the current behaviour. Deviations from the planned policy are documented; implementing sink retry/DLQ is future work.
+The `AckCoordinator` is the **sole commit authority**. No component ever interacts with the source checkpoint directly — all commits flow through coordinator barriers.
 
+## Scenario Matrix
+
+| Scenario                        | Behaviour                                                                                                                                              | Commit?          | Notes                                                                                |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------- | ------------------------------------------------------------------------------------ |
+| Transform OK → All sinks ack    | Barrier refs reach 0, CAS `Live→Committed`                                                                                                             | **Yes**          | Standard happy path.                                                                 |
+| Transform returns error         | Runner retries per stage policy. On exhaustion, `Fail()` dead-letters the frame. If all derived frames are dropped, `CommitNow()` advances the offset. | **Conditional**  | Offset advances only when nothing reaches sinks, or when surviving barriers resolve. |
+| Sink publish error              | `barrier.Abort()` prevents commit. `Fail()` invokes the dead-letter handler.                                                                           | **No**           | Offset stays; source will redeliver.                                                 |
+| AckAware sink confirms delivery | Sink calls `coord.Ack(tok)` → barrier `release()` decrements refs.                                                                                     | **When refs=0**  | Each sink acks independently.                                                        |
+| Transformer DROP                | No derived frames → `CommitNow(tok)` immediately.                                                                                                      | **Yes**          | Treated as successful filter.                                                        |
+| Fan-out (N frames × M sinks)    | Barrier created with `refs = N×M + 1`. Each sink ack decrements. Sync sinks call `Complete()`.                                                         | **When all ack** | Single barrier covers entire fan-out.                                                |
+| Context cancellation            | Outstanding barriers abandoned, no commit.                                                                                                             | **No**           | Shutdown safety.                                                                     |
+
+## Coordinator Flow
+
+```mermaid
+sequenceDiagram
+  participant Source
+  participant Runner
+  participant Coord as AckCoordinator
+  participant Sink as AckAware Sink
+  participant DLQ as DeadLetterFn
+
+  Source->>Runner: emit(ctx, frame)
+  Runner->>Runner: transform chain → N frames
+
+  alt N = 0 (all dropped)
+    Runner->>Coord: CommitNow(tok)
+    Coord->>Source: commit offset
+  else N > 0
+    Runner->>Coord: Barrier(tok, refs)
+    Runner->>Sink: Publish(frame₁..frameₙ)
+
+    alt publish succeeds
+      Sink-->>Coord: Ack(tok) × N
+      Note over Coord: refs=0 → commit
+      Coord->>Source: commit offset
+    else publish fails
+      Runner->>Coord: barrier.Abort()
+      Runner->>Coord: Fail(stage, frame, err)
+      Coord->>DLQ: dead-letter
+      Note over Coord: no commit
+    end
+  end
+```
+
+## Barrier Lifecycle
+
+```mermaid
+stateDiagram-v2
+  [*] --> Live : Barrier(tok, refs)
+  Live --> Committed : all refs released (CAS)
+  Live --> Aborted : publishAll fails (CAS)
+  Committed --> [*] : offset committed
+  Aborted --> [*] : offset withheld
+```
+
+## Duplicate Delivery
+
+If the source redelivers a frame whose barrier is still outstanding, the coordinator force-aborts the stale barrier and creates a fresh one. This prevents resource leaks from abandoned barriers.

--- a/docs/specs/error-handling.md
+++ b/docs/specs/error-handling.md
@@ -1,16 +1,48 @@
 # Error Handling
 
-| Stage Outcome | Commit Offset? | Retry? | Notes |
-|---------------|----------------|--------|-------|
-| Transform success → Sink success | Yes | No | Standard flow. |
-| Transform error | No (E2E) | Yes, bounded by stage config | Offset is withheld until retry succeeds. After exhaustion, frame is acknowledged (future DLQ support). |
-| Sink error | No (E2E) | Planned retry/backoff | Currently surfaces error and halts pipeline; upcoming milestones add retry + DLQ. |
-| Transformer `DROP` | Yes | No | Treated as successful filter. |
-| Context cancelled | No | No | Shutdown aborts in-flight work without committing. |
+## Error Classification
+
+| Stage Outcome                     | Commit Offset?        | Retry?                       | Dead-Letter? | Notes                                                                       |
+| --------------------------------- | --------------------- | ---------------------------- | ------------ | --------------------------------------------------------------------------- |
+| Transform success → All sinks ack | Yes                   | No                           | No           | Barrier refs reach 0 → `Live→Committed`.                                    |
+| Transform transient error         | No (pending)          | Yes, bounded by stage config | No           | Retried with backoff. After exhaustion → permanent failure.                 |
+| Transform permanent error         | Conditional           | No                           | Yes          | `Fail()` dead-letters. If no frames survive, `CommitNow()` advances offset. |
+| Sink publish error                | No                    | No (barrier aborted)         | Yes          | `barrier.Abort()` prevents commit. `Fail()` invokes `DeadLetterFn`.         |
+| AckAware sink delivery failure    | Yes (ack still fires) | Broker-level                 | No           | Sarama pump acks on both Successes and Errors — at-least-once semantics.    |
+| Transformer `DROP`                | Yes                   | No                           | No           | No derived frames → `CommitNow()`.                                          |
+| Context cancelled                 | No                    | No                           | No           | Outstanding barriers abandoned. Shutdown safety.                            |
+
+## Dead-Letter Handler
+
+The `AckCoordinator.Fail(stage, frame, cause)` method invokes the registered `DeadLetterFn`:
+
+```go
+type DeadLetterFn func(stage string, frame *pb.Frame, cause error)
+```
+
+- Set via `Runner.SetDeadLetter(fn)` → `coord.SetDeadLetter(fn)`
+- Called for permanently failed frames after retry exhaustion
+- The checkpoint lifecycle is handled by the caller (`pushFrame`): if all derived frames fail, `CommitNow()` advances the offset; if some survive, the surviving barrier commits when sinks ack
+
+## Error Flow
+
+```mermaid
+flowchart TD
+  frame["Source Frame"] --> transform["Transform Chain"]
+  transform -->|OK| publish["publishAll"]
+  transform -->|DROP| commitNow["CommitNow(tok)"]
+  transform -->|ERROR after retries| fail["Fail(stage, frame, err)"]
+
+  publish -->|success| ackWait["Wait for sink acks"]
+  publish -->|error| abort["barrier.Abort()"]
+
+  ackWait -->|all refs=0| commit["Commit offset"]
+  abort --> dlq["DeadLetterFn"]
+  fail --> dlq
+```
 
 ## Hooks
 
-- Stage configuration controls retry count and backoff duration.
-- Sink adapters will expose retry/backoff knobs (`retry.*`) and DLQ settings in later milestones.
-- Metrics: upcoming work adds counters for publish attempts/errors, retry totals, and DLQ writes.
-
+- Stage configuration controls retry count and backoff duration per transformer.
+- Sink adapters expose retry/backoff knobs (`retry.*`) in their config.
+- Metrics: publish attempts/errors, retry totals, barrier commit/abort counts via `AckCoordinator.Len()` observability.

--- a/docs/specs/pipeline.md
+++ b/docs/specs/pipeline.md
@@ -8,22 +8,50 @@
 
 ## Filter Semantics
 
-- A filter returns `DROP` (or emits no events). The runner acknowledges the original frame immediately and stops the chain.
+- A filter returns `DROP` (or emits no events). The runner calls `coord.CommitNow(tok)` immediately and stops the chain.
 - Filters must be side-effect free aside from emitting metrics/logs.
 
 ## Runner Flow
 
 1. Source emits `emit(ctx, frame)`.
-2. Runner iterates through transformers.
-3. Resulting frames are published to each sink in order-of-registration.
-4. When sinks acknowledge, the runner notifies the source (`Ack`).
+2. Runner iterates through transformers → produces `N` derived frames (0 if all dropped/failed).
+3. If `N = 0`: `coord.CommitNow(tok)` — offset advances immediately.
+4. If `N > 0`: Runner creates a **barrier** via `coord.Barrier(tok, refs)` where `refs = N × ackAwareSinks + 1` (sync sinks).
+5. `publishAll` sends each derived frame to every sink.
+6. **AckAware sinks** (Kafka, S3) call `coord.Ack(tok)` asynchronously when delivery confirms — each call decrements the barrier's refcount.
+7. **Synchronous sinks** (stdout) complete inline — Runner calls `barrier.Complete()` after all sync publishes return.
+8. When refs reach 0, the barrier CAS transitions `Live → Committed` and the coordinator commits the checkpoint to the source.
+
+```mermaid
+flowchart TD
+  emit["source.emit(ctx, frame)"] --> chain["Transform chain"]
+  chain -->|"N = 0"| commitNow["coord.CommitNow(tok)"]
+  chain -->|"N > 0"| barrier["coord.Barrier(tok, refs)"]
+  barrier --> publish["publishAll(frames)"]
+
+  publish -->|success| ackPhase["AckAware: Ack(tok) × N\nSync: barrier.Complete()"]
+  publish -->|error| abort["barrier.Abort()"]
+
+  ackPhase -->|"refs = 0"| commit["Commit offset"]
+  abort --> noCommit["No commit (redeliver)"]
+```
+
+## Fan-Out
+
+When a transformer produces multiple output frames from a single input, or when multiple AckAware sinks are configured, the barrier's reference count covers every combination:
+
+```
+refs = len(derivedFrames) × ackAwareSinks + (1 if syncSinks > 0 or ackAwareSinks == 0)
+```
+
+Each sink independently decrements the barrier. The checkpoint only commits when **every** sink has acknowledged **every** derived frame.
 
 ## Retry Policy
 
 - Each stage defines `retry_attempts` and `backoff_ms`. Retries use the same context with timeout wrappers.
-- Exhaustion logs the failure and acknowledges the frame to prevent deadlock. Future DLQ support will capture these events.
+- Exhaustion invokes `coord.Fail(stage, frame, cause)` which dead-letters the frame. The checkpoint lifecycle depends on whether other derived frames survive.
 
 ## Observability Hooks
 
-- Logging is provided via `internal/logging`. Metrics for publish attempts/errors are introduced alongside sink retry (see future milestones).
-
+- `AckCoordinator.Len()` reports outstanding unresolved barriers — useful for monitoring pipeline health and backpressure.
+- Logging via `internal/logging`. Metrics for publish attempts/errors provided through `internal/telemetry`.

--- a/docs/specs/sink.md
+++ b/docs/specs/sink.md
@@ -10,6 +10,29 @@ type Adapter interface {
 }
 ```
 
+## AckAware Interface
+
+Sinks that confirm delivery asynchronously implement `AckAware`:
+
+```go
+type EmitFn func(*pb.CheckpointToken)
+
+type AckAware interface {
+    BindAck(EmitFn)
+}
+```
+
+During pipeline wiring, `Runner.AddSink` detects `AckAware` sinks and calls `BindAck(coord.Ack)`, binding the sink directly to the `AckCoordinator`. When the sink confirms delivery, it invokes `EmitFn` with the frame's checkpoint token — the coordinator's barrier decrements its refcount and commits when all sinks have acked.
+
+### AckAware vs Synchronous Sinks
+
+| Property            | AckAware Sink                  | Synchronous Sink                               |
+| ------------------- | ------------------------------ | ---------------------------------------------- |
+| `Publish` behaviour | Non-blocking enqueue           | Blocking write                                 |
+| Ack mechanism       | Calls `EmitFn(tok)` on confirm | Runner calls `barrier.Complete()` after return |
+| Barrier refs        | `N frames × M ackAware sinks`  | `+1` for all sync sinks combined               |
+| Examples            | Kafka, S3                      | Stdout                                         |
+
 ## Registration
 
 Drivers register using `sink.Register(sink.Registration{Name: "kafka", New: func() Adapter { ... }, ConfigProto: func() any { return Config{} }})`. The pipeline requests the adapter and hands it a decoded config struct.
@@ -18,7 +41,39 @@ Drivers register using `sink.Register(sink.Registration{Name: "kafka", New: func
 
 - `Publish` must respect cancellation. If the context deadline is exceeded, return `ctx.Err()` and avoid acknowledging the frame.
 - The adapter should treat frames as immutable. Any batching must copy payloads/headers.
-- On success, `AckAware` sinks invoke the provided ack callback.
+- **AckAware sinks** attach the checkpoint token to in-flight metadata (e.g., Sarama's `msg.Metadata`) and ack asynchronously when the broker confirms delivery.
+- **Synchronous sinks** return from `Publish` once the write is complete; the runner treats the return as implicit acknowledgement.
+
+## Kafka Sink (AckAware)
+
+The Kafka sink uses Sarama's `AsyncProducer`:
+
+```mermaid
+sequenceDiagram
+  participant Runner
+  participant KafkaSink
+  participant AsyncProducer as Sarama AsyncProducer
+  participant Coordinator as AckCoordinator
+
+  Runner->>KafkaSink: Publish(frame)
+  KafkaSink->>AsyncProducer: Input() ← msg{Metadata: inflight{tok}}
+  Note over KafkaSink: returns immediately (non-blocking)
+
+  AsyncProducer-->>KafkaSink: Successes channel
+  KafkaSink->>KafkaSink: pump() extracts inflight
+  KafkaSink->>Coordinator: Ack(tok)
+```
+
+- `Publish` attaches `&inflight{checkpoint: frame.Checkpoint}` as `msg.Metadata` and sends to `prod.Input()`.
+- `pump()` goroutine reads both `Successes` and `Errors` channels, extracts the `inflight` metadata, and calls `Ack(tok)` on both paths (at-least-once: the message was either delivered or the offset should advance past the error).
+- `Close` calls `AsyncClose()` and blocks on `<-doneCh` until `pump()` drains.
+
+## S3 Sink (AckAware)
+
+The S3 sink batches frames and uploads on flush:
+
+- `uploadBatch` collects checkpoint tokens from all frames in the batch.
+- On success **or** failure, `ackAll()` calls `EmitFn(tok)` for every token in the batch — ensuring barriers are never left dangling.
 
 ## Ordering & Idempotence
 
@@ -28,4 +83,4 @@ Drivers register using `sink.Register(sink.Registration{Name: "kafka", New: func
 ## Shutdown
 
 - `Close` should flush and release resources. It receives the same root context used to start the pipeline.
-
+- AckAware sinks must drain in-flight acknowledgements before returning from `Close`.

--- a/internal/config/pipeline.go
+++ b/internal/config/pipeline.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -88,8 +87,7 @@ func LoadPipelineSpec(path string) (PipelineConfig, error) {
 		cfg.SchemaVersion = SupportedPipelineSchema
 	}
 	if cfg.SchemaVersion != SupportedPipelineSchema {
-		return cfg, qerr.Config("pipeline", "validate",
-			fmt.Errorf("schema_version %q not supported (want %q)", cfg.SchemaVersion, SupportedPipelineSchema))
+		return cfg, qerr.Config("pipeline", "validate", errors.New("unsupported schema_version"))
 	}
 
 	if cfg.SinkConfigs == nil {
@@ -143,24 +141,20 @@ func (c PipelineConfig) validate() error {
 	if c.Source.Config == "" && c.Source.Inline.Node == nil {
 		return qerr.Config("pipeline", "validate", errors.New("source.config or source.inline required"))
 	}
-	for i, t := range c.Transformers {
+	for _, t := range c.Transformers {
 		if t.Name == "" {
-			return qerr.Config("pipeline", "validate",
-				fmt.Errorf("transformers[%d].name required", i))
+			return qerr.Config("pipeline", "validate", errors.New("transformer name required"))
 		}
 		if t.Type == "" {
-			return qerr.Config("pipeline", "validate",
-				fmt.Errorf("transformers[%d].type required", i))
+			return qerr.Config("pipeline", "validate", errors.New("transformer type required"))
 		}
 		switch t.Type {
 		case "grpc":
 			if t.Address == "" {
-				return qerr.Config("pipeline", "validate",
-					fmt.Errorf("transformers[%d].address required for grpc", i))
+				return qerr.Config("pipeline", "validate", errors.New("transformer address required for grpc"))
 			}
 		default:
-			return qerr.Config("pipeline", "validate",
-				fmt.Errorf("unsupported transformer type %q", t.Type))
+			return qerr.Config("pipeline", "validate", errors.New("unsupported transformer type"))
 		}
 	}
 	return nil

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2,9 +2,13 @@ package engine
 
 import (
 	"context"
+	"log/slog"
+	"time"
 
 	"quanta/internal/pipeline"
 	"quanta/internal/transport"
+
+	"golang.org/x/sync/errgroup"
 )
 
 type Engine struct {
@@ -12,14 +16,53 @@ type Engine struct {
 	runner    *pipeline.Runner
 }
 
-func (e *Engine) Run(ctx context.Context) error {
-	go func() {
-		<-ctx.Done()
-		if e.runner != nil {
-			_ = e.runner.Close(ctx)
-		}
-		e.transport.Stop()
-	}()
+const _shutdownGrace = 10 * time.Second
 
-	return e.transport.Serve()
+func (e *Engine) Run(ctx context.Context) error {
+	g, gCtx := errgroup.WithContext(ctx)
+
+	// Worker: watch for source failure or context cancellation.
+	g.Go(func() error {
+		return e.watchLifecycle(gCtx)
+	})
+
+	// Worker: serve gRPC transport.
+	g.Go(func() error {
+		return e.transport.Serve()
+	})
+
+	err := g.Wait()
+
+	e.shutdown(ctx)
+	return err
+}
+
+func (e *Engine) watchLifecycle(ctx context.Context) error {
+	if e.runner == nil {
+		<-ctx.Done()
+		e.transport.Stop()
+		return ctx.Err()
+	}
+
+	select {
+	case <-ctx.Done():
+		e.transport.Stop()
+		return ctx.Err()
+	case err := <-e.runner.SourceErr():
+		slog.Error("engine: source terminated unexpectedly", "error", err)
+		e.transport.Stop()
+		return err
+	}
+}
+
+func (e *Engine) shutdown(ctx context.Context) {
+	if e.runner == nil {
+		return
+	}
+	slog.Warn("engine: draining pipeline")
+	closeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), _shutdownGrace)
+	defer cancel()
+	if err := e.runner.Close(closeCtx); err != nil {
+		slog.Error("engine: runner close error", "error", err)
+	}
 }

--- a/internal/pipeline/ack_coordinator.go
+++ b/internal/pipeline/ack_coordinator.go
@@ -1,0 +1,217 @@
+package pipeline
+
+import (
+	"log/slog"
+	"math"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	pb "quanta/api/proto/v1"
+)
+
+const (
+	_barrierLive      int32 = 0
+	_barrierCommitted int32 = 1
+	_barrierAborted   int32 = 2
+)
+
+// Barrier controls the lifecycle of a single checkpoint commit decision.
+type Barrier interface {
+	Complete()
+	Abort()
+}
+
+// AckCoordinator centralized checkpoint lifecycle manager.
+// The coordinator is the ONLY component that commits checkpoints back to
+// the source.
+type AckCoordinator struct {
+	mu       sync.Mutex
+	subs     []func(*pb.ConnectorAck)
+	barriers map[string]*ackBarrier
+	dlFn     DeadLetterFn
+}
+
+func NewAckCoordinator() *AckCoordinator {
+	return &AckCoordinator{
+		barriers: make(map[string]*ackBarrier),
+	}
+}
+
+func (c *AckCoordinator) Subscribe(fn func(*pb.ConnectorAck)) {
+	c.mu.Lock()
+	c.subs = append(c.subs, fn)
+	c.mu.Unlock()
+}
+
+func (c *AckCoordinator) SetDeadLetter(fn DeadLetterFn) {
+	c.mu.Lock()
+	c.dlFn = fn
+	c.mu.Unlock()
+}
+
+// Barrier creates a refcounted completion barrier for a checkpoint.
+// refs is the number of Complete/Ack calls required before commit.
+//
+// If a barrier already exists for this token (source redelivery), the
+// stale barrier is force-aborted and replaced.
+//
+// Nil tokens produce a valid barrier that is not tracked  Complete and
+// Abort are safe but no commit fires.
+func (c *AckCoordinator) Barrier(tok *pb.CheckpointToken, refs int) Barrier {
+	if refs < 0 || refs > math.MaxInt32 {
+		slog.Warn("ackBarrier: refs out of int32 range, clamping", "refs", refs)
+		refs = 0
+	}
+	b := &ackBarrier{token: tok, coord: c}
+	b.refs.Store(int32(refs)) //nolint:gosec // bounds-checked above
+
+	key := tokenKey(tok)
+	if key == "" {
+		return b
+	}
+
+	c.mu.Lock()
+	if old, exists := c.barriers[key]; exists {
+		slog.Warn("ackBarrier: duplicate key, aborting stale barrier", "key", key)
+		old.state.CompareAndSwap(_barrierLive, _barrierAborted)
+	}
+	c.barriers[key] = b
+	c.mu.Unlock()
+	return b
+}
+
+// Ack is the callback given to AckAware sinks satisfies sink.EmitFn.
+// Thread-safe. No-op if no barrier exists or token is nil.
+func (c *AckCoordinator) Ack(tok *pb.CheckpointToken) {
+	key := tokenKey(tok)
+	if key == "" {
+		return
+	}
+	c.mu.Lock()
+	b := c.barriers[key]
+	c.mu.Unlock()
+	if b == nil {
+		return
+	}
+	b.release()
+}
+
+// CommitNow immediately commits a checkpoint without creating a barrier.
+// Used when all derived frames are dropped/failed and nothing reaches sinks.
+// No-op for nil tokens.
+func (c *AckCoordinator) CommitNow(tok *pb.CheckpointToken) {
+	if tok == nil {
+		return
+	}
+	c.commit(tok)
+}
+
+// Fail invokes the dead-letter handler for a permanently failed frame.
+// The checkpoint lifecycle is handled by the caller pushFrame:
+//   - All frames fail pushFrame calls CommitNow
+//   - Some frames survive → the surviving barrier commits when sinks ack
+func (c *AckCoordinator) Fail(stage string, frame *pb.Frame, cause error) {
+	slog.Error("permanent failure, dead-lettering frame",
+		"stage", stage, "error", cause)
+	c.mu.Lock()
+	fn := c.dlFn
+	c.mu.Unlock()
+	if fn != nil {
+		fn(stage, frame, cause)
+	}
+}
+
+// Len returns the number of outstanding unresolved barriers.
+func (c *AckCoordinator) Len() int {
+	c.mu.Lock()
+	n := len(c.barriers)
+	c.mu.Unlock()
+	return n
+}
+
+func (c *AckCoordinator) commit(tok *pb.CheckpointToken) {
+	if tok == nil {
+		return
+	}
+	ack := &pb.ConnectorAck{Checkpoint: tok}
+
+	c.mu.Lock()
+	handlers := make([]func(*pb.ConnectorAck), len(c.subs))
+	copy(handlers, c.subs)
+	c.mu.Unlock()
+
+	for _, fn := range handlers {
+		fn(ack)
+	}
+}
+
+func (c *AckCoordinator) removeBarrier(b *ackBarrier) {
+	key := tokenKey(b.token)
+	if key == "" {
+		return
+	}
+	c.mu.Lock()
+	if c.barriers[key] == b {
+		delete(c.barriers, key)
+	}
+	c.mu.Unlock()
+}
+
+var _ Barrier = (*ackBarrier)(nil)
+
+type ackBarrier struct {
+	token *pb.CheckpointToken
+	refs  atomic.Int32
+	state atomic.Int32
+	coord *AckCoordinator
+}
+
+func (b *ackBarrier) Complete() {
+	b.release()
+}
+
+// Abort transitions the barrier to aborted. No commit fires.
+// Safe to call concurrently with release CAS arbitrates.
+func (b *ackBarrier) Abort() {
+	if b.state.CompareAndSwap(_barrierLive, _barrierAborted) {
+		b.coord.removeBarrier(b)
+	}
+}
+
+func (b *ackBarrier) release() {
+	n := b.refs.Add(-1)
+	if n < 0 {
+		slog.Warn("ackBarrier: refcount underflow",
+			"key", tokenKey(b.token), "refs", n)
+	}
+	if n <= 0 && b.state.CompareAndSwap(_barrierLive, _barrierCommitted) {
+		b.coord.removeBarrier(b)
+		b.coord.commit(b.token)
+	}
+}
+
+func tokenKey(tok *pb.CheckpointToken) string {
+	if tok == nil {
+		return ""
+	}
+	switch k := tok.Kind.(type) {
+	case *pb.CheckpointToken_Kafka:
+		buf := make([]byte, 0, 64)
+		buf = append(buf, "k:"...)
+		buf = append(buf, k.Kafka.Topic...)
+		buf = append(buf, '/')
+		buf = strconv.AppendInt(buf, int64(k.Kafka.Partition), 10)
+		buf = append(buf, '/')
+		buf = strconv.AppendInt(buf, k.Kafka.Offset, 10)
+		return string(buf)
+	case *pb.CheckpointToken_Sqs:
+		return "s:" + k.Sqs.Queue + "/" + k.Sqs.Handle
+	case *pb.CheckpointToken_Http:
+		return "h:" + k.Http.Id
+	case *pb.CheckpointToken_Raw:
+		return "r:" + string(k.Raw)
+	default:
+		return ""
+	}
+}

--- a/internal/pipeline/ack_coordinator_test.go
+++ b/internal/pipeline/ack_coordinator_test.go
@@ -1,0 +1,462 @@
+package pipeline
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	pb "quanta/api/proto/v1"
+)
+
+func kafkaTok(topic string, partition int32, offset int64) *pb.CheckpointToken {
+	return &pb.CheckpointToken{Kind: &pb.CheckpointToken_Kafka{
+		Kafka: &pb.KafkaOffset{Topic: topic, Partition: partition, Offset: offset},
+	}}
+}
+
+func TestTokenKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		give *pb.CheckpointToken
+		want string
+	}{
+		{
+			name: "kafka",
+			give: kafkaTok("orders", 3, 1000),
+			want: "k:orders/3/1000",
+		},
+		{
+			name: "sqs",
+			give: &pb.CheckpointToken{Kind: &pb.CheckpointToken_Sqs{
+				Sqs: &pb.SqsHandle{Queue: "q", Handle: "h"},
+			}},
+			want: "s:q/h",
+		},
+		{
+			name: "http",
+			give: &pb.CheckpointToken{Kind: &pb.CheckpointToken_Http{
+				Http: &pb.HttpAckID{Id: "abc"},
+			}},
+			want: "h:abc",
+		},
+		{
+			name: "raw",
+			give: &pb.CheckpointToken{Kind: &pb.CheckpointToken_Raw{
+				Raw: []byte("payload-id"),
+			}},
+			want: "r:payload-id",
+		},
+		{
+			name: "nil_token",
+			give: nil,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tokenKey(tt.give)
+			if got != tt.want {
+				t.Fatalf("tokenKey: got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAckCoordinator_BarrierComplete(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		refs     int
+		wantAcks int
+	}{
+		{name: "refs_1_single_complete", refs: 1, wantAcks: 1},
+		{name: "refs_3_all_completed", refs: 3, wantAcks: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ac := &ackCounter{}
+			coord := NewAckCoordinator()
+			coord.Subscribe(ac.handler)
+
+			tok := kafkaTok("t", 0, 100)
+			b := coord.Barrier(tok, tt.refs)
+
+			for i := 0; i < tt.refs; i++ {
+				b.Complete()
+			}
+
+			if got := ac.get(); got != tt.wantAcks {
+				t.Fatalf("commit count: got %d, want %d", got, tt.wantAcks)
+			}
+		})
+	}
+}
+
+func TestAckCoordinator_BarrierAbortPreventsCommit(t *testing.T) {
+	t.Parallel()
+
+	ac := &ackCounter{}
+	coord := NewAckCoordinator()
+	coord.Subscribe(ac.handler)
+
+	tok := kafkaTok("t", 0, 200)
+	b := coord.Barrier(tok, 1)
+	b.Abort()
+
+	b.Complete()
+
+	if got := ac.get(); got != 0 {
+		t.Fatalf("commit count: got %d, want 0 (abort must prevent commit)", got)
+	}
+}
+
+func TestAckCoordinator_AckResolvesBarrier(t *testing.T) {
+	t.Parallel()
+
+	ac := &ackCounter{}
+	coord := NewAckCoordinator()
+	coord.Subscribe(ac.handler)
+
+	tok := kafkaTok("t", 1, 300)
+	coord.Barrier(tok, 2)
+
+	coord.Ack(tok)
+	coord.Ack(tok)
+
+	if got := ac.get(); got != 1 {
+		t.Fatalf("commit count: got %d, want 1", got)
+	}
+}
+
+func TestAckCoordinator_AckNoBarrierIsNoop(t *testing.T) {
+	t.Parallel()
+
+	ac := &ackCounter{}
+	coord := NewAckCoordinator()
+	coord.Subscribe(ac.handler)
+
+	coord.Ack(kafkaTok("t", 0, 999))
+
+	if got := ac.get(); got != 0 {
+		t.Fatalf("commit count: got %d, want 0", got)
+	}
+}
+
+func TestAckCoordinator_CommitNow(t *testing.T) {
+	t.Parallel()
+
+	ac := &ackCounter{}
+	coord := NewAckCoordinator()
+	coord.Subscribe(ac.handler)
+
+	coord.CommitNow(kafkaTok("t", 0, 50))
+
+	if got := ac.get(); got != 1 {
+		t.Fatalf("commit count: got %d, want 1", got)
+	}
+}
+
+func TestAckCoordinator_Fail(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		dlSet    bool
+		wantDL   int
+		wantAcks int
+	}{
+		{name: "with_dl_handler", dlSet: true, wantDL: 1, wantAcks: 0},
+		{name: "no_dl_handler", dlSet: false, wantDL: 0, wantAcks: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ac := &ackCounter{}
+			dl := &deadLetterCapture{}
+			coord := NewAckCoordinator()
+			coord.Subscribe(ac.handler)
+			if tt.dlSet {
+				coord.SetDeadLetter(dl.fn)
+			}
+
+			frame := &pb.Frame{
+				Value:      []byte("bad"),
+				Checkpoint: kafkaTok("t", 0, 77),
+			}
+			coord.Fail("stage-x", frame, errTest)
+
+			if dl.len() != tt.wantDL {
+				t.Fatalf("dl entries: got %d, want %d", dl.len(), tt.wantDL)
+			}
+
+			if got := ac.get(); got != tt.wantAcks {
+				t.Fatalf("commit count: got %d, want %d", got, tt.wantAcks)
+			}
+		})
+	}
+}
+
+var errTest = errorString("test error")
+
+type errorString string
+
+func (e errorString) Error() string { return string(e) }
+
+func TestAckCoordinator_ConcurrentRelease(t *testing.T) {
+	t.Parallel()
+
+	var commitCount atomic.Int32
+	coord := NewAckCoordinator()
+	coord.Subscribe(func(*pb.ConnectorAck) {
+		commitCount.Add(1)
+	})
+
+	const goroutines = 100
+	tok := kafkaTok("t", 0, 500)
+	coord.Barrier(tok, goroutines)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			coord.Ack(tok)
+		}()
+	}
+	wg.Wait()
+
+	if got := commitCount.Load(); got != 1 {
+		t.Fatalf("concurrent release: commit count %d, want exactly 1", got)
+	}
+}
+
+func TestAckCoordinator_BarrierCleanedUp(t *testing.T) {
+	t.Parallel()
+
+	coord := NewAckCoordinator()
+	tok := kafkaTok("t", 0, 600)
+
+	coord.Barrier(tok, 1)
+
+	if coord.Len() != 1 {
+		t.Fatal("barrier should be present before completion")
+	}
+
+	coord.Ack(tok)
+
+	if coord.Len() != 0 {
+		t.Fatal("barrier should be removed after commit")
+	}
+}
+
+func TestAckBarrier_UnderflowSafe(t *testing.T) {
+	t.Parallel()
+
+	ac := &ackCounter{}
+	coord := NewAckCoordinator()
+	coord.Subscribe(ac.handler)
+
+	tok := kafkaTok("t", 0, 800)
+	b := coord.Barrier(tok, 1)
+
+	b.Complete()
+	b.Complete()
+	if got := ac.get(); got != 1 {
+		t.Fatalf("commit count: got %d, want 1 (underflow must not double-commit)", got)
+	}
+}
+
+func TestAckCoordinator_DuplicateBarrier(t *testing.T) {
+	t.Parallel()
+
+	ac := &ackCounter{}
+	coord := NewAckCoordinator()
+	coord.Subscribe(ac.handler)
+
+	tok := kafkaTok("t", 0, 900)
+
+	b1 := coord.Barrier(tok, 1)
+	b2 := coord.Barrier(tok, 1)
+	b1.Complete()
+	if got := ac.get(); got != 0 {
+		t.Fatalf("stale barrier committed: got %d, want 0", got)
+	}
+
+	b2.Complete()
+	if got := ac.get(); got != 1 {
+		t.Fatalf("new barrier: got %d commits, want 1", got)
+	}
+
+	if coord.Len() != 0 {
+		t.Fatal("all barriers should be cleaned up")
+	}
+}
+
+func TestAckCoordinator_NilToken(t *testing.T) {
+	t.Parallel()
+
+	t.Run("barrier_complete_noop", func(t *testing.T) {
+		t.Parallel()
+		ac := &ackCounter{}
+		coord := NewAckCoordinator()
+		coord.Subscribe(ac.handler)
+
+		b := coord.Barrier(nil, 1)
+		b.Complete()
+
+		if got := ac.get(); got != 0 {
+			t.Fatalf("nil-token barrier must not commit: got %d", got)
+		}
+		if coord.Len() != 0 {
+			t.Fatal("nil-token barrier must not be tracked in map")
+		}
+	})
+
+	t.Run("barrier_abort_noop", func(t *testing.T) {
+		t.Parallel()
+		coord := NewAckCoordinator()
+		b := coord.Barrier(nil, 1)
+		b.Abort() // must not panic
+	})
+
+	t.Run("ack_noop", func(t *testing.T) {
+		t.Parallel()
+		ac := &ackCounter{}
+		coord := NewAckCoordinator()
+		coord.Subscribe(ac.handler)
+
+		coord.Ack(nil) // must not panic
+		if got := ac.get(); got != 0 {
+			t.Fatalf("nil ack must be noop: got %d", got)
+		}
+	})
+
+	t.Run("commit_now_noop", func(t *testing.T) {
+		t.Parallel()
+		ac := &ackCounter{}
+		coord := NewAckCoordinator()
+		coord.Subscribe(ac.handler)
+
+		coord.CommitNow(nil) // must not commit
+		if got := ac.get(); got != 0 {
+			t.Fatalf("nil CommitNow must be noop: got %d", got)
+		}
+	})
+}
+
+func TestAckBarrier_AbortThenRelease(t *testing.T) {
+	t.Parallel()
+
+	ac := &ackCounter{}
+	coord := NewAckCoordinator()
+	coord.Subscribe(ac.handler)
+
+	tok := kafkaTok("t", 0, 1100)
+	b := coord.Barrier(tok, 2)
+
+	// Simulate one sink acks, then runner aborts due to another sink failure.
+	b.Complete() // refs -> 1
+	b.Abort()    // state aborted, barrier removed from map
+	b.Complete() // refs -> 0, but state is aborted -> CAS fails -> no commit
+
+	if got := ac.get(); got != 0 {
+		t.Fatalf("aborted barrier must not commit: got %d", got)
+	}
+	if coord.Len() != 0 {
+		t.Fatal("aborted barrier must be removed from map")
+	}
+}
+
+func TestAckCoordinator_RemoveBarrierPointerSafe(t *testing.T) {
+	t.Parallel()
+
+	ac := &ackCounter{}
+	coord := NewAckCoordinator()
+	coord.Subscribe(ac.handler)
+
+	tok := kafkaTok("t", 0, 1000)
+
+	b1 := coord.Barrier(tok, 2)
+	b2 := coord.Barrier(tok, 1)
+
+	b1.Complete()
+	if coord.Len() != 1 {
+		t.Fatalf("B2 must still be in map: Len=%d", coord.Len())
+	}
+
+	b2.Complete()
+	if got := ac.get(); got != 1 {
+		t.Fatalf("B2 commit: got %d, want 1", got)
+	}
+	if coord.Len() != 0 {
+		t.Fatal("all barriers should be cleaned up")
+	}
+}
+
+func TestAckCoordinator_Len(t *testing.T) {
+	t.Parallel()
+
+	coord := NewAckCoordinator()
+	if coord.Len() != 0 {
+		t.Fatal("empty coordinator must have Len=0")
+	}
+
+	tok1 := kafkaTok("t", 0, 1)
+	tok2 := kafkaTok("t", 0, 2)
+	tok3 := kafkaTok("t", 0, 3)
+
+	coord.Barrier(tok1, 1)
+	coord.Barrier(tok2, 1)
+	coord.Barrier(tok3, 1)
+
+	if coord.Len() != 3 {
+		t.Fatalf("Len: got %d, want 3", coord.Len())
+	}
+
+	coord.Ack(tok1)
+	if coord.Len() != 2 {
+		t.Fatalf("Len after 1 ack: got %d, want 2", coord.Len())
+	}
+
+	coord.Ack(tok2)
+	coord.Ack(tok3)
+	if coord.Len() != 0 {
+		t.Fatalf("Len after all acks: got %d, want 0", coord.Len())
+	}
+}
+
+func TestAckCoordinator_FailNeverCommits(t *testing.T) {
+	t.Parallel()
+
+	ac := &ackCounter{}
+	dl := &deadLetterCapture{}
+	coord := NewAckCoordinator()
+	coord.Subscribe(ac.handler)
+	coord.SetDeadLetter(dl.fn)
+
+	tok := kafkaTok("t", 0, 1200)
+	coord.Barrier(tok, 1)
+
+	frame := &pb.Frame{Value: []byte("bad"), Checkpoint: tok}
+	coord.Fail("stage-x", frame, errTest)
+
+	if dl.len() != 1 {
+		t.Fatalf("dl entries: got %d, want 1", dl.len())
+	}
+	if got := ac.get(); got != 0 {
+		t.Fatalf("Fail must not commit: got %d, want 0", got)
+	}
+	if coord.Len() != 1 {
+		t.Fatalf("barrier must remain until pushFrame resolves: Len=%d", coord.Len())
+	}
+}

--- a/internal/pipeline/compiler.go
+++ b/internal/pipeline/compiler.go
@@ -2,7 +2,7 @@ package pipeline
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"quanta/internal/config"
 	qerr "quanta/internal/errors"
@@ -17,7 +17,8 @@ func Compile(ctx context.Context, path string) (*Runner, error) {
 		return nil, qerr.Pipeline("config", err)
 	}
 
-	r := NewRunner()
+	coord := NewAckCoordinator()
+	r := NewRunner(coord)
 
 	if err := compileSource(ctx, cfg, r); err != nil {
 		return nil, err
@@ -40,7 +41,7 @@ func compileSource(ctx context.Context, cfg config.PipelineConfig, r *Runner) er
 
 	confPath := cfg.Source.ResolvedConfigPath()
 	if confPath == "" {
-		return qerr.Config(cfg.Source.Kind, "resolve", fmt.Errorf("missing config_file for source %q", cfg.Source.Kind))
+		return qerr.Config(cfg.Source.Kind, "resolve", errors.New("missing config_file for source"))
 	}
 
 	sourceCfg, err := source.LoadConfig(cfg.Source.Kind, confPath)
@@ -77,9 +78,9 @@ func newTransformClient(ctx context.Context, t config.TransformerConfig) (transf
 		}
 		return cli, nil
 	case "inproc":
-		return nil, qerr.Transform(t.Name, "create", fmt.Errorf("in-proc transformer not yet supported"))
+		return nil, qerr.Transform(t.Name, "create", errors.New("in-proc transformer not yet supported"))
 	default:
-		return nil, qerr.Transform(t.Name, "create", fmt.Errorf("unsupported transformer type %q", t.Type))
+		return nil, qerr.Transform(t.Name, "create", errors.New("unsupported transformer type"))
 	}
 }
 
@@ -102,9 +103,6 @@ func compileSinks(ctx context.Context, cfg config.PipelineConfig, r *Runner) err
 			return qerr.Sink(name, "configure", err)
 		}
 
-		if ackAware, ok := drv.(sink.AckAware); ok {
-			ackAware.BindAck(r.Ack)
-		}
 		r.AddSink(drv)
 	}
 	return nil

--- a/internal/pipeline/runner.go
+++ b/internal/pipeline/runner.go
@@ -53,6 +53,9 @@ type transformStage struct {
 }
 
 func NewRunner(coord *AckCoordinator) *Runner {
+	if coord == nil {
+		coord = NewAckCoordinator()
+	}
 	return &Runner{
 		stages:    make([]transformStage, 0, 4),
 		sinks:     make([]sink.Adapter, 0, 2),
@@ -100,7 +103,11 @@ func (r *Runner) Start(ctx context.Context) error {
 			return r.pushFrame(runCtx, frame)
 		})
 		if err != nil && ctx.Err() == nil {
-			r.sourceErr <- qerr.Pipeline("source-run", err)
+			select {
+			case r.sourceErr <- qerr.Pipeline("source-run", err):
+			default:
+				slog.Warn("engine: dropping source error; no receiver", "error", err)
+			}
 		}
 	}()
 	return nil

--- a/internal/pipeline/runner.go
+++ b/internal/pipeline/runner.go
@@ -3,8 +3,8 @@ package pipeline
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"strconv"
-	"sync"
 	"time"
 
 	pb "quanta/api/proto/v1"
@@ -13,16 +13,35 @@ import (
 	"quanta/sink"
 	"quanta/source"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+type transformOutcome int8
+
+const (
+	outcomeEvents transformOutcome = iota
+
+	outcomeDrop
+
+	outcomeFailed
+
+	outcomeAbort
+)
+
+type DeadLetterFn func(stage string, frame *pb.Frame, cause error)
 
 type Runner struct {
 	source source.Adapter
 	sinks  []sink.Adapter
 	stages []transformStage
 
-	mu   sync.Mutex
-	subs []func(*pb.ConnectorAck)
+	coord *AckCoordinator
+
+	ackAwareSinks int
+
+	sourceErr chan error
 }
 
 type transformStage struct {
@@ -33,16 +52,30 @@ type transformStage struct {
 	retryBackoff  time.Duration
 }
 
-func NewRunner() *Runner {
+func NewRunner(coord *AckCoordinator) *Runner {
 	return &Runner{
-		stages: make([]transformStage, 0, 4),
-		sinks:  make([]sink.Adapter, 0, 2),
+		stages:    make([]transformStage, 0, 4),
+		sinks:     make([]sink.Adapter, 0, 2),
+		sourceErr: make(chan error, 1),
+		coord:     coord,
 	}
 }
 
-func (r *Runner) SetSource(s source.Adapter) { r.source = s }
+func (r *Runner) SetSource(s source.Adapter) {
+	r.source = s
+}
 
-func (r *Runner) AddSink(s sink.Adapter) { r.sinks = append(r.sinks, s) }
+func (r *Runner) AddSink(s sink.Adapter) {
+	if ackAware, ok := s.(sink.AckAware); ok {
+		ackAware.BindAck(r.coord.Ack)
+		r.ackAwareSinks++
+	}
+	r.sinks = append(r.sinks, s)
+}
+
+func (r *Runner) SetDeadLetter(fn DeadLetterFn) {
+	r.coord.SetDeadLetter(fn)
+}
 
 func (r *Runner) AddTransformer(name string, c transform.Client, timeout time.Duration, attempts int, backoff time.Duration) {
 	r.stages = append(r.stages, transformStage{
@@ -55,22 +88,7 @@ func (r *Runner) AddTransformer(name string, c transform.Client, timeout time.Du
 }
 
 func (r *Runner) SubscribeAck(fn func(*pb.ConnectorAck)) {
-	r.mu.Lock()
-	r.subs = append(r.subs, fn)
-	r.mu.Unlock()
-}
-
-func (r *Runner) Ack(tok *pb.CheckpointToken) {
-	ack := &pb.ConnectorAck{Checkpoint: tok}
-
-	r.mu.Lock()
-	handlers := make([]func(*pb.ConnectorAck), len(r.subs))
-	copy(handlers, r.subs)
-	r.mu.Unlock()
-
-	for _, fn := range handlers {
-		fn(ack)
-	}
+	r.coord.Subscribe(fn)
 }
 
 func (r *Runner) Start(ctx context.Context) error {
@@ -78,21 +96,33 @@ func (r *Runner) Start(ctx context.Context) error {
 		return qerr.Pipeline("start", errors.New("no source configured"))
 	}
 	go func() {
-		_ = r.source.Run(ctx, func(runCtx context.Context, frame *pb.Frame) error {
+		err := r.source.Run(ctx, func(runCtx context.Context, frame *pb.Frame) error {
 			return r.pushFrame(runCtx, frame)
 		})
+		if err != nil && ctx.Err() == nil {
+			r.sourceErr <- qerr.Pipeline("source-run", err)
+		}
 	}()
 	return nil
 }
 
+func (r *Runner) SourceErr() <-chan error {
+	return r.sourceErr
+}
+
 func (r *Runner) Close(ctx context.Context) error {
+	var errs []error
 	for _, st := range r.stages {
-		_ = st.client.Close()
+		if err := st.client.Close(); err != nil {
+			errs = append(errs, qerr.Transform(st.name, "close", err))
+		}
 	}
 	for _, s := range r.sinks {
-		_ = s.Close(ctx)
+		if err := s.Close(ctx); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (r *Runner) pushFrame(ctx context.Context, f *pb.Frame) error {
@@ -103,69 +133,187 @@ func (r *Runner) pushFrame(ctx context.Context, f *pb.Frame) error {
 	}
 
 	if len(frames) == 0 {
-		r.Ack(f.Checkpoint)
+		r.coord.CommitNow(f.Checkpoint)
 		return nil
 	}
 
+	syncSinks := len(r.sinks) - r.ackAwareSinks
+	refs := len(frames) * r.ackAwareSinks
+	if syncSinks > 0 || r.ackAwareSinks == 0 {
+		refs++
+	}
+
+	barrier := r.coord.Barrier(f.Checkpoint, refs)
+
 	if err := r.publishAll(ctx, frames); err != nil {
+		barrier.Abort()
 		return err
 	}
 
-	r.Ack(f.Checkpoint)
+	if syncSinks > 0 || r.ackAwareSinks == 0 {
+		barrier.Complete()
+	}
+
 	return nil
 }
 
 func (r *Runner) runStage(ctx context.Context, st transformStage, in []*pb.Frame) []*pb.Frame {
 	out := make([]*pb.Frame, 0, len(in))
 	for _, f := range in {
-		events := r.callTransform(ctx, st, f)
-		if events == nil {
-			continue
+		outcome, events := r.callTransform(ctx, st, f)
+		switch outcome {
+		case outcomeEvents:
+			out = append(out, toFrames(f, events)...)
+		case outcomeDrop, outcomeFailed:
+			// no-op: filtered or dead-lettered
+		case outcomeAbort:
+			// context cancelled, stop processing
 		}
-		out = append(out, toFrames(f, events)...)
 	}
 	return out
 }
 
-func (r *Runner) callTransform(ctx context.Context, st transformStage, f *pb.Frame) []*pb.Event {
+func (r *Runner) callTransform(ctx context.Context, st transformStage, f *pb.Frame) (transformOutcome, []*pb.Event) {
 	req := toRequest(f)
 	req.PluginId = st.name
 
 	for try := 0; ; try++ {
+		if ctx.Err() != nil {
+			return outcomeAbort, nil
+		}
+
 		callCtx, cancel := r.stageContext(ctx, st.timeout)
 		resp, err := st.client.Transform(callCtx, req)
 		cancel()
 
 		if err != nil {
-			if try < st.retryAttempts {
-				time.Sleep(st.retryBackoff)
+			outcome, retry := r.handleTransportError(ctx, st, f, err, try)
+			if retry {
 				continue
 			}
-			r.Ack(f.Checkpoint)
-			return nil
+			return outcome, nil
 		}
 
-		switch resp.GetStatus() {
-		case pb.Status_OK:
-			return resp.GetEvents()
-		case pb.Status_DROP:
-			r.Ack(f.Checkpoint)
-			return nil
-		case pb.Status_RETRY, pb.Status_ERROR:
-			if try < st.retryAttempts {
-				time.Sleep(st.retryBackoff)
-				continue
-			}
-			r.Ack(f.Checkpoint)
-			return nil
-		default:
-			if try < st.retryAttempts {
-				time.Sleep(st.retryBackoff)
-				continue
-			}
-			r.Ack(f.Checkpoint)
-			return nil
+		outcome, events, retry := r.handleResponse(ctx, st, f, resp, try)
+		if retry {
+			continue
 		}
+		return outcome, events
+	}
+}
+
+func (r *Runner) handleTransportError(ctx context.Context, st transformStage, f *pb.Frame, err error, try int) (transformOutcome, bool) {
+	isTimeout := errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+	if isTimeout && ctx.Err() != nil {
+		return outcomeAbort, false
+	}
+
+	if isTimeout || isTransientGRPC(err) {
+		switch r.retryOrExhaust(ctx, st, try) {
+		case retryProceed:
+			return 0, true
+		case retryAbort:
+			return outcomeAbort, false
+		case retryExhaust:
+		}
+		return r.handlePermanentFailure(st, f, err), false
+	}
+
+	slog.Warn("transform permanent transport error",
+		"stage", st.name,
+		"code", status.Code(err).String(),
+		"error", err,
+	)
+	return r.handlePermanentFailure(st, f, err), false
+}
+
+func (r *Runner) handleResponse(ctx context.Context, st transformStage, f *pb.Frame, resp *pb.TransformResponse, try int) (transformOutcome, []*pb.Event, bool) {
+	switch resp.GetStatus() {
+	case pb.Status_OK:
+		return outcomeEvents, resp.GetEvents(), false
+
+	case pb.Status_DROP:
+		slog.Debug("transform frame dropped by plugin",
+			"stage", st.name,
+		)
+		return outcomeDrop, nil, false
+
+	case pb.Status_RETRY:
+		switch r.retryOrExhaust(ctx, st, try) {
+		case retryProceed:
+			return 0, nil, true
+		case retryAbort:
+			return outcomeAbort, nil, false
+		case retryExhaust:
+		}
+		return r.handlePermanentFailure(st, f,
+			errors.New("plugin returned RETRY but retries exhausted")), nil, false
+
+	case pb.Status_ERROR:
+		slog.Error("transform plugin returned permanent ERROR",
+			"stage", st.name,
+		)
+		return r.handlePermanentFailure(st, f,
+			errors.New("plugin returned permanent ERROR")), nil, false
+
+	default:
+		slog.Error("transform unknown status from plugin",
+			"stage", st.name,
+			"status", resp.GetStatus().String(),
+		)
+		return r.handlePermanentFailure(st, f,
+			errors.New("plugin returned unknown status")), nil, false
+	}
+}
+
+type retryVerdict int8
+
+const (
+	retryProceed retryVerdict = iota
+	retryExhaust
+	retryAbort
+)
+
+func (r *Runner) retryOrExhaust(ctx context.Context, st transformStage, try int) retryVerdict {
+	if try >= st.retryAttempts {
+		return retryExhaust
+	}
+	slog.Debug("transform retrying",
+		"stage", st.name,
+		"attempt", try+1,
+		"max", st.retryAttempts,
+	)
+	if r.backoffOrCancel(ctx, st.retryBackoff) {
+		return retryProceed
+	}
+	return retryAbort
+}
+
+func (r *Runner) handlePermanentFailure(st transformStage, f *pb.Frame, cause error) transformOutcome {
+	r.coord.Fail(st.name, f, cause)
+	return outcomeFailed
+}
+
+func isTransientGRPC(err error) bool {
+	switch status.Code(err) {
+	case codes.Unavailable,
+		codes.DeadlineExceeded,
+		codes.ResourceExhausted,
+		codes.Aborted:
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *Runner) backoffOrCancel(ctx context.Context, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
 	}
 }
 

--- a/internal/pipeline/runner_test.go
+++ b/internal/pipeline/runner_test.go
@@ -2,14 +2,20 @@ package pipeline
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	pb "quanta/api/proto/v1"
+	qerr "quanta/internal/errors"
 	"quanta/sink"
+	"quanta/source"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type fakeTransform struct {
@@ -17,17 +23,19 @@ type fakeTransform struct {
 	mode  string
 }
 
-func (f *fakeTransform) Metadata(ctx context.Context) (*pb.MetadataResponse, error) {
+func (f *fakeTransform) Metadata(context.Context) (*pb.MetadataResponse, error) {
 	return &pb.MetadataResponse{}, nil
 }
-func (f *fakeTransform) Health(ctx context.Context) (*pb.HealthResponse, error) {
+
+func (f *fakeTransform) Health(context.Context) (*pb.HealthResponse, error) {
 	return &pb.HealthResponse{Ok: true}, nil
 }
-func (f *fakeTransform) Stream(ctx context.Context, opts ...grpc.CallOption) (pb.TransformService_TransformStreamClient, error) {
+
+func (f *fakeTransform) Stream(context.Context, ...grpc.CallOption) (pb.TransformService_TransformStreamClient, error) {
 	return nil, nil
 }
 func (f *fakeTransform) Close() error { return nil }
-func (f *fakeTransform) Transform(ctx context.Context, req *pb.TransformRequest) (*pb.TransformResponse, error) {
+func (f *fakeTransform) Transform(_ context.Context, req *pb.TransformRequest) (*pb.TransformResponse, error) {
 	c := atomic.AddInt32(&f.calls, 1)
 	switch f.mode {
 	case "ok":
@@ -36,24 +44,53 @@ func (f *fakeTransform) Transform(ctx context.Context, req *pb.TransformRequest)
 		return &pb.TransformResponse{Status: pb.Status_DROP}, nil
 	case "errorThenOK":
 		if c == 1 {
-			return &pb.TransformResponse{Status: pb.Status_ERROR}, nil
+			return &pb.TransformResponse{Status: pb.Status_RETRY}, nil
 		}
 		return &pb.TransformResponse{Status: pb.Status_OK, Events: []*pb.Event{{Value: append([]byte{}, req.Payload...)}}}, nil
 	case "fanout2":
 		return &pb.TransformResponse{Status: pb.Status_OK, Events: []*pb.Event{{Value: append([]byte{}, req.Payload...)}, {Value: append([]byte{}, req.Payload...)}}}, nil
+	case "permanent_error":
+		return &pb.TransformResponse{Status: pb.Status_ERROR}, nil
+	case "retry_always":
+		return &pb.TransformResponse{Status: pb.Status_RETRY}, nil
 	default:
 		return &pb.TransformResponse{Status: pb.Status_OK, Events: []*pb.Event{{Value: append([]byte{}, req.Payload...)}}}, nil
 	}
 }
 
+type grpcErrTransform struct {
+	fakeTransform
+	code      codes.Code
+	callCount int32
+	succeedAt int32
+}
+
+func (g *grpcErrTransform) Transform(_ context.Context, req *pb.TransformRequest) (*pb.TransformResponse, error) {
+	c := atomic.AddInt32(&g.callCount, 1)
+	if g.succeedAt > 0 && c >= g.succeedAt {
+		return &pb.TransformResponse{Status: pb.Status_OK, Events: []*pb.Event{{Value: append([]byte{}, req.Payload...)}}}, nil
+	}
+	return nil, status.Error(g.code, "simulated gRPC error")
+}
+
+type failTransformClose struct {
+	fakeTransform
+	err error
+}
+
+func (f *failTransformClose) Close() error { return f.err }
+
 type captureSink struct {
+	mu     sync.Mutex
 	pushed []*pb.Frame
 	ackFn  sink.EmitFn
 }
 
 func (c *captureSink) Configure(context.Context, any) error { return nil }
-func (c *captureSink) Publish(ctx context.Context, f *pb.Frame) error {
+func (c *captureSink) Publish(_ context.Context, f *pb.Frame) error {
+	c.mu.Lock()
 	c.pushed = append(c.pushed, f)
+	c.mu.Unlock()
 	if c.ackFn != nil {
 		c.ackFn(f.Checkpoint)
 	}
@@ -62,81 +99,696 @@ func (c *captureSink) Publish(ctx context.Context, f *pb.Frame) error {
 func (c *captureSink) Close(context.Context) error { return nil }
 func (c *captureSink) BindAck(fn sink.EmitFn)      { c.ackFn = fn }
 
+type failSink struct{ err error }
+
+func (f *failSink) Configure(context.Context, any) error     { return nil }
+func (f *failSink) Publish(context.Context, *pb.Frame) error { return nil }
+func (f *failSink) Close(context.Context) error              { return f.err }
+
+type fakeSource struct {
+	runErr error
+	block  bool
+}
+
+func (s *fakeSource) Configure(context.Context, any) error { return nil }
+func (s *fakeSource) Run(ctx context.Context, _ source.EmitFunc) error {
+	if s.block {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	return s.runErr
+}
+func (s *fakeSource) OnAck(*pb.ConnectorAck)      {}
+func (s *fakeSource) Close(context.Context) error { return nil }
+
+type deadLetterCapture struct {
+	mu      sync.Mutex
+	entries []dlEntry
+}
+
+type dlEntry struct {
+	stage string
+	frame *pb.Frame
+	cause error
+}
+
+func (d *deadLetterCapture) fn(stage string, frame *pb.Frame, cause error) {
+	d.mu.Lock()
+	d.entries = append(d.entries, dlEntry{stage: stage, frame: frame, cause: cause})
+	d.mu.Unlock()
+}
+
+func (d *deadLetterCapture) len() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.entries)
+}
+
+func (d *deadLetterCapture) get(i int) dlEntry {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.entries[i]
+}
+
 func makeFrame() *pb.Frame {
-	return &pb.Frame{Value: []byte("hello"), Checkpoint: &pb.CheckpointToken{Kind: &pb.CheckpointToken_Kafka{Kafka: &pb.KafkaOffset{Topic: "t", Partition: 1, Offset: 42}}}}
-}
-
-func TestRunner_TransformerOK_ForwardsAndSinkAcks(t *testing.T) {
-	r := NewRunner()
-	fake := &fakeTransform{mode: "ok"}
-	r.AddTransformer("t1", fake, 100*time.Millisecond, 0, 0)
-	cs := &captureSink{}
-	cs.BindAck(r.Ack)
-	r.AddSink(cs)
-
-	f := makeFrame()
-	if err := r.pushFrame(context.Background(), f); err != nil {
-		t.Fatalf("pushFrame: %v", err)
-	}
-	if len(cs.pushed) != 1 {
-		t.Fatalf("expected 1 pushed frame, got %d", len(cs.pushed))
-	}
-	if string(cs.pushed[0].Value) != "hello" {
-		t.Fatalf("unexpected value: %q", cs.pushed[0].Value)
+	return &pb.Frame{
+		Value: []byte("hello"),
+		Checkpoint: &pb.CheckpointToken{Kind: &pb.CheckpointToken_Kafka{
+			Kafka: &pb.KafkaOffset{Topic: "t", Partition: 1, Offset: 42},
+		}},
 	}
 }
 
-func TestRunner_TransformerDrop_AcksNoPush(t *testing.T) {
-	r := NewRunner()
-	fake := &fakeTransform{mode: "drop"}
-	r.AddTransformer("t1", fake, 100*time.Millisecond, 0, 0)
-	cs := &captureSink{}
-	cs.BindAck(r.Ack)
-	r.AddSink(cs)
+type ackCounter struct {
+	mu    sync.Mutex
+	count int
+}
 
-	f := makeFrame()
-	if err := r.pushFrame(context.Background(), f); err != nil {
-		t.Fatalf("pushFrame: %v", err)
+func (a *ackCounter) handler(ack *pb.ConnectorAck) {
+	a.mu.Lock()
+	a.count++
+	a.mu.Unlock()
+}
+
+func (a *ackCounter) get() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.count
+}
+
+func newTestRunner() *Runner {
+	return NewRunner(NewAckCoordinator())
+}
+
+func TestRunner_PushFrame(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		mode       string
+		retries    int
+		wantPushed int
+		wantValue  string
+	}{
+		{
+			name:       "transformer_ok_forwards_to_sink",
+			mode:       "ok",
+			retries:    0,
+			wantPushed: 1,
+			wantValue:  "hello",
+		},
+		{
+			name:       "transformer_drop_acks_no_push",
+			mode:       "drop",
+			retries:    0,
+			wantPushed: 0,
+		},
+		{
+			name:       "transformer_retry_then_ok",
+			mode:       "errorThenOK",
+			retries:    1,
+			wantPushed: 1,
+			wantValue:  "hello",
+		},
+		{
+			name:       "multi_stage_fanout",
+			mode:       "fanout2",
+			retries:    0,
+			wantPushed: 2,
+			wantValue:  "hello",
+		},
 	}
-	if len(cs.pushed) != 0 {
-		t.Fatalf("expected 0 pushed frames on DROP, got %d", len(cs.pushed))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := newTestRunner()
+			fake := &fakeTransform{mode: tt.mode}
+			r.AddTransformer("t1", fake, 100*time.Millisecond, tt.retries, 1*time.Millisecond)
+
+			if tt.mode == "fanout2" {
+				r.AddTransformer("t2", &fakeTransform{mode: "ok"}, 100*time.Millisecond, 0, 0)
+			}
+
+			cs := &captureSink{}
+			r.AddSink(cs)
+
+			if err := r.pushFrame(context.Background(), makeFrame()); err != nil {
+				t.Fatalf("pushFrame: %v", err)
+			}
+
+			cs.mu.Lock()
+			got := len(cs.pushed)
+			cs.mu.Unlock()
+
+			if got != tt.wantPushed {
+				t.Fatalf("pushed frames: got %d, want %d", got, tt.wantPushed)
+			}
+			if tt.wantPushed > 0 && tt.wantValue != "" {
+				cs.mu.Lock()
+				val := string(cs.pushed[0].Value)
+				cs.mu.Unlock()
+				if val != tt.wantValue {
+					t.Fatalf("pushed value: got %q, want %q", val, tt.wantValue)
+				}
+			}
+		})
 	}
 }
 
-func TestRunner_TransformerRetryThenOK(t *testing.T) {
-	r := NewRunner()
-	fake := &fakeTransform{mode: "errorThenOK"}
+func TestCallTransform_ErrorClassification(t *testing.T) {
+	t.Parallel()
 
-	r.AddTransformer("t1", fake, 100*time.Millisecond, 1, 1*time.Millisecond)
-	cs := &captureSink{}
-	cs.BindAck(r.Ack)
-	r.AddSink(cs)
-
-	f := makeFrame()
-	if err := r.pushFrame(context.Background(), f); err != nil {
-		t.Fatalf("pushFrame: %v", err)
+	tests := []struct {
+		name           string
+		client         func() *grpcErrTransform
+		retries        int
+		wantOutcome    transformOutcome
+		wantRetryCalls int32
+		wantDL         bool
+	}{
+		{
+			name:           "transient_unavailable_retried_then_dead_letter",
+			client:         func() *grpcErrTransform { return &grpcErrTransform{code: codes.Unavailable} },
+			retries:        2,
+			wantOutcome:    outcomeFailed,
+			wantRetryCalls: 3,
+			wantDL:         true,
+		},
+		{
+			name:           "transient_resource_exhausted_retried",
+			client:         func() *grpcErrTransform { return &grpcErrTransform{code: codes.ResourceExhausted} },
+			retries:        1,
+			wantOutcome:    outcomeFailed,
+			wantRetryCalls: 2,
+			wantDL:         true,
+		},
+		{
+			name:           "transient_succeeds_on_retry",
+			client:         func() *grpcErrTransform { return &grpcErrTransform{code: codes.Unavailable, succeedAt: 2} },
+			retries:        3,
+			wantOutcome:    outcomeEvents,
+			wantRetryCalls: 2,
+			wantDL:         false,
+		},
+		{
+			name:           "permanent_invalid_argument_never_retried",
+			client:         func() *grpcErrTransform { return &grpcErrTransform{code: codes.InvalidArgument} },
+			retries:        5,
+			wantOutcome:    outcomeFailed,
+			wantRetryCalls: 1,
+			wantDL:         true,
+		},
+		{
+			name:           "permanent_unimplemented_never_retried",
+			client:         func() *grpcErrTransform { return &grpcErrTransform{code: codes.Unimplemented} },
+			retries:        3,
+			wantOutcome:    outcomeFailed,
+			wantRetryCalls: 1,
+			wantDL:         true,
+		},
+		{
+			name:           "permanent_permission_denied_never_retried",
+			client:         func() *grpcErrTransform { return &grpcErrTransform{code: codes.PermissionDenied} },
+			retries:        3,
+			wantOutcome:    outcomeFailed,
+			wantRetryCalls: 1,
+			wantDL:         true,
+		},
+		{
+			name:           "permanent_internal_never_retried",
+			client:         func() *grpcErrTransform { return &grpcErrTransform{code: codes.Internal} },
+			retries:        3,
+			wantOutcome:    outcomeFailed,
+			wantRetryCalls: 1,
+			wantDL:         true,
+		},
 	}
-	if len(cs.pushed) != 1 {
-		t.Fatalf("expected 1 pushed frame after retry, got %d", len(cs.pushed))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cli := tt.client()
+			r := newTestRunner()
+			dl := &deadLetterCapture{}
+			r.coord.SetDeadLetter(dl.fn)
+			r.AddTransformer("test", cli, 50*time.Millisecond, tt.retries, 1*time.Millisecond)
+			r.AddSink(&captureSink{})
+
+			outcome, _ := r.callTransform(context.Background(),
+				r.stages[0], makeFrame())
+
+			if outcome != tt.wantOutcome {
+				t.Fatalf("outcome: got %d, want %d", outcome, tt.wantOutcome)
+			}
+
+			calls := atomic.LoadInt32(&cli.callCount)
+			if calls != tt.wantRetryCalls {
+				t.Fatalf("Transform calls: got %d, want %d", calls, tt.wantRetryCalls)
+			}
+
+			if tt.wantDL {
+				if dl.len() != 1 {
+					t.Fatalf("dead-letter entries: got %d, want 1", dl.len())
+				}
+			} else {
+				if dl.len() != 0 {
+					t.Fatalf("dead-letter entries: got %d, want 0", dl.len())
+				}
+			}
+		})
 	}
 }
 
-func TestRunner_MultiStageFanout(t *testing.T) {
-	r := NewRunner()
+func TestCallTransform_StatusClassification(t *testing.T) {
+	t.Parallel()
 
-	stage1 := &fakeTransform{mode: "fanout2"}
-	stage2 := &fakeTransform{mode: "ok"}
-	r.AddTransformer("s1", stage1, 100*time.Millisecond, 0, 0)
-	r.AddTransformer("s2", stage2, 100*time.Millisecond, 0, 0)
-	cs := &captureSink{}
-	cs.BindAck(r.Ack)
-	r.AddSink(cs)
+	tests := []struct {
+		name        string
+		mode        string
+		retries     int
+		wantOutcome transformOutcome
+		wantCalls   int32
+		wantDL      bool
+	}{
+		{
+			name:        "status_ok_no_retry",
+			mode:        "ok",
+			retries:     3,
+			wantOutcome: outcomeEvents,
+			wantCalls:   1,
+		},
+		{
+			name:        "status_drop_no_retry_no_dead_letter",
+			mode:        "drop",
+			retries:     3,
+			wantOutcome: outcomeDrop,
+			wantCalls:   1,
+		},
+		{
+			name:        "status_error_permanent_never_retried",
+			mode:        "permanent_error",
+			retries:     5,
+			wantOutcome: outcomeFailed,
+			wantCalls:   1,
+			wantDL:      true,
+		},
+		{
+			name:        "status_retry_retried_then_dead_letter",
+			mode:        "retry_always",
+			retries:     2,
+			wantOutcome: outcomeFailed,
+			wantCalls:   3,
+			wantDL:      true,
+		},
+		{
+			name:        "status_retry_succeeds_on_second_attempt",
+			mode:        "errorThenOK",
+			retries:     2,
+			wantOutcome: outcomeEvents,
+			wantCalls:   2,
+		},
+	}
 
-	f := makeFrame()
-	if err := r.pushFrame(context.Background(), f); err != nil {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fake := &fakeTransform{mode: tt.mode}
+			r := newTestRunner()
+			dl := &deadLetterCapture{}
+			r.coord.SetDeadLetter(dl.fn)
+			r.AddTransformer("test", fake, 100*time.Millisecond, tt.retries, 1*time.Millisecond)
+			r.AddSink(&captureSink{})
+
+			outcome, _ := r.callTransform(context.Background(),
+				r.stages[0], makeFrame())
+
+			if outcome != tt.wantOutcome {
+				t.Fatalf("outcome: got %d, want %d", outcome, tt.wantOutcome)
+			}
+
+			calls := atomic.LoadInt32(&fake.calls)
+			if calls != tt.wantCalls {
+				t.Fatalf("Transform calls: got %d, want %d", calls, tt.wantCalls)
+			}
+
+			if tt.wantDL && dl.len() == 0 {
+				t.Fatal("expected dead-letter entry, got none")
+			}
+			if !tt.wantDL && dl.len() > 0 {
+				t.Fatalf("unexpected dead-letter entries: %d", dl.len())
+			}
+		})
+	}
+}
+
+func TestCallTransform_DeadLetterReceivesFrame(t *testing.T) {
+	t.Parallel()
+
+	dl := &deadLetterCapture{}
+	r := newTestRunner()
+	r.coord.SetDeadLetter(dl.fn)
+
+	cli := &grpcErrTransform{code: codes.InvalidArgument}
+	r.AddTransformer("dl-stage", cli, 50*time.Millisecond, 0, 0)
+	r.AddSink(&captureSink{})
+
+	frame := makeFrame()
+	outcome, _ := r.callTransform(context.Background(), r.stages[0], frame)
+
+	if outcome != outcomeFailed {
+		t.Fatalf("outcome: got %d, want outcomeFailed", outcome)
+	}
+	if dl.len() != 1 {
+		t.Fatalf("dead-letter entries: got %d, want 1", dl.len())
+	}
+
+	entry := dl.get(0)
+	if entry.stage != "dl-stage" {
+		t.Fatalf("dead-letter stage: got %q, want %q", entry.stage, "dl-stage")
+	}
+	if entry.frame != frame {
+		t.Fatal("dead-letter must receive the original frame pointer")
+	}
+	if entry.cause == nil {
+		t.Fatal("dead-letter cause must not be nil")
+	}
+}
+
+func TestCallTransform_ContextCancelled_AbortsImmediately(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		cancelIn  time.Duration
+		retries   int
+		wantCalls int32
+	}{
+		{
+			name:      "pre_cancelled_context_zero_calls",
+			cancelIn:  0,
+			retries:   10,
+			wantCalls: 0,
+		},
+		{
+			name:      "cancelled_during_backoff_stops_quickly",
+			cancelIn:  5 * time.Millisecond,
+			retries:   100,
+			wantCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			if tt.cancelIn == 0 {
+				cancel()
+			} else {
+				go func() {
+					time.Sleep(tt.cancelIn)
+					cancel()
+				}()
+				defer cancel()
+			}
+
+			cli := &grpcErrTransform{code: codes.Unavailable}
+			r := newTestRunner()
+			r.AddTransformer("ctx-test", cli, 50*time.Millisecond, tt.retries, 50*time.Millisecond)
+			r.AddSink(&captureSink{})
+
+			start := time.Now()
+			outcome, _ := r.callTransform(ctx, r.stages[0], makeFrame())
+			elapsed := time.Since(start)
+
+			if outcome != outcomeAbort {
+				t.Fatalf("outcome: got %d, want outcomeAbort", outcome)
+			}
+
+			calls := atomic.LoadInt32(&cli.callCount)
+			if calls > tt.wantCalls+1 {
+				t.Fatalf("Transform calls: got %d, wanted at most %d", calls, tt.wantCalls+1)
+			}
+
+			if elapsed > 1*time.Second {
+				t.Fatalf("context cancellation too slow: took %v", elapsed)
+			}
+		})
+	}
+}
+
+func TestPushFrame_SingleAckOnDrop(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRunner()
+	r.AddTransformer("dropper", &fakeTransform{mode: "drop"}, 100*time.Millisecond, 0, 0)
+	r.AddSink(&failSink{})
+
+	ac := &ackCounter{}
+	r.coord.Subscribe(ac.handler)
+
+	if err := r.pushFrame(context.Background(), makeFrame()); err != nil {
 		t.Fatalf("pushFrame: %v", err)
 	}
-	if len(cs.pushed) != 2 {
-		t.Fatalf("expected 2 pushed frames after fanout, got %d", len(cs.pushed))
+
+	if got := ac.get(); got != 1 {
+		t.Fatalf("ack count: got %d, want exactly 1", got)
+	}
+}
+
+func TestPushFrame_SingleAckOnPermanentError(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRunner()
+	r.coord.SetDeadLetter(func(string, *pb.Frame, error) {})
+	r.AddTransformer("broken", &fakeTransform{mode: "permanent_error"}, 100*time.Millisecond, 0, 0)
+	r.AddSink(&failSink{})
+
+	ac := &ackCounter{}
+	r.coord.Subscribe(ac.handler)
+
+	if err := r.pushFrame(context.Background(), makeFrame()); err != nil {
+		t.Fatalf("pushFrame: %v", err)
+	}
+
+	if got := ac.get(); got != 1 {
+		t.Fatalf("ack count: got %d, want exactly 1", got)
+	}
+}
+
+func TestPushFrame_SingleAckOnOK(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRunner()
+	r.AddTransformer("pass", &fakeTransform{mode: "ok"}, 100*time.Millisecond, 0, 0)
+	cs := &captureSink{}
+	r.AddSink(cs)
+
+	ac := &ackCounter{}
+	r.coord.Subscribe(ac.handler)
+
+	if err := r.pushFrame(context.Background(), makeFrame()); err != nil {
+		t.Fatalf("pushFrame: %v", err)
+	}
+
+	if got := ac.get(); got != 1 {
+		t.Fatalf("ack count: got %d, want exactly 1", got)
+	}
+}
+
+func TestPushFrame_FanOutSingleAck(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRunner()
+	r.AddTransformer("fan", &fakeTransform{mode: "fanout2"}, 100*time.Millisecond, 0, 0)
+	cs := &captureSink{}
+	r.AddSink(cs)
+
+	ac := &ackCounter{}
+	r.coord.Subscribe(ac.handler)
+
+	if err := r.pushFrame(context.Background(), makeFrame()); err != nil {
+		t.Fatalf("pushFrame: %v", err)
+	}
+
+	cs.mu.Lock()
+	pushed := len(cs.pushed)
+	cs.mu.Unlock()
+	if pushed != 2 {
+		t.Fatalf("pushed frames: got %d, want 2", pushed)
+	}
+
+	if got := ac.get(); got != 1 {
+		t.Fatalf("ack count: got %d, want exactly 1 (fan-out must not multiply acks)", got)
+	}
+}
+
+func TestRunner_SourceErr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		source   *fakeSource
+		wantErr  bool
+		wantKind qerr.Kind
+	}{
+		{
+			name:     "source_fails_propagates_pipeline_error",
+			source:   &fakeSource{runErr: errors.New("broker down")},
+			wantErr:  true,
+			wantKind: qerr.KindPipeline,
+		},
+		{
+			name:    "source_blocks_then_cancelled_no_error",
+			source:  &fakeSource{block: true},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := newTestRunner()
+			r.SetSource(tt.source)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			if err := r.Start(ctx); err != nil {
+				t.Fatalf("Start: %v", err)
+			}
+
+			if tt.wantErr {
+				select {
+				case err := <-r.SourceErr():
+					if err == nil {
+						t.Fatal("expected non-nil error on SourceErr channel")
+					}
+					if !qerr.IsKind(err, tt.wantKind) {
+						t.Fatalf("expected kind %v, got: %v", tt.wantKind, err)
+					}
+				case <-time.After(2 * time.Second):
+					t.Fatal("timed out waiting for SourceErr")
+				}
+			} else {
+				cancel()
+				select {
+				case err := <-r.SourceErr():
+					t.Fatalf("unexpected error on SourceErr: %v", err)
+				case <-time.After(200 * time.Millisecond):
+				}
+			}
+		})
+	}
+}
+
+func TestRunner_Start_NoSource(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRunner()
+	err := r.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected error when no source configured")
+	}
+	if !qerr.IsPipeline(err) {
+		t.Fatalf("expected pipeline error, got: %v", err)
+	}
+}
+
+func TestRunner_Close_ErrorAggregation(t *testing.T) {
+	t.Parallel()
+
+	errTransform := errors.New("transform close failed")
+	errSink := errors.New("sink close failed")
+
+	tests := []struct {
+		name          string
+		transformErr  error
+		sinkErr       error
+		wantNil       bool
+		wantTransform bool
+		wantSink      bool
+	}{
+		{name: "no_errors_returns_nil", wantNil: true},
+		{name: "transform_error", transformErr: errTransform, wantTransform: true},
+		{name: "sink_error", sinkErr: errSink, wantSink: true},
+		{name: "both_joined", transformErr: errTransform, sinkErr: errSink, wantTransform: true, wantSink: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := newTestRunner()
+			if tt.transformErr != nil {
+				r.AddTransformer("broken", &failTransformClose{err: tt.transformErr}, 0, 0, 0)
+			} else {
+				r.AddTransformer("ok", &fakeTransform{mode: "ok"}, 0, 0, 0)
+			}
+			if tt.sinkErr != nil {
+				r.AddSink(&failSink{err: tt.sinkErr})
+			} else {
+				r.AddSink(&captureSink{})
+			}
+
+			err := r.Close(context.Background())
+			if tt.wantNil {
+				if err != nil {
+					t.Fatalf("expected nil, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if tt.wantTransform && !errors.Is(err, tt.transformErr) {
+				t.Fatalf("missing transform error in chain: %v", err)
+			}
+			if tt.wantSink && !errors.Is(err, tt.sinkErr) {
+				t.Fatalf("missing sink error in chain: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunner_BackoffOrCancel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		duration   time.Duration
+		cancelIn   time.Duration
+		wantResult bool
+	}{
+		{name: "completes_normally", duration: 5 * time.Millisecond, wantResult: true},
+		{name: "cancelled_during", duration: 5 * time.Second, cancelIn: 10 * time.Millisecond, wantResult: false},
+		{name: "already_cancelled", duration: 5 * time.Second, cancelIn: 1 * time.Nanosecond, wantResult: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := newTestRunner()
+			ctx, cancel := context.WithCancel(context.Background())
+			if tt.cancelIn > 0 {
+				go func() {
+					time.Sleep(tt.cancelIn)
+					cancel()
+				}()
+			} else {
+				defer cancel()
+			}
+
+			got := r.backoffOrCancel(ctx, tt.duration)
+			if got != tt.wantResult {
+				t.Fatalf("got %v, want %v", got, tt.wantResult)
+			}
+		})
 	}
 }

--- a/internal/transport/client.go
+++ b/internal/transport/client.go
@@ -2,6 +2,7 @@ package transport
 
 import (
 	"fmt"
+	"io"
 
 	pb "quanta/api/proto/v1"
 	qerr "quanta/internal/errors"
@@ -10,7 +11,18 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func Dial(port int) (pb.ControlClient, error) {
+type ClientConn struct {
+	pb.ControlClient
+	conn *grpc.ClientConn
+}
+
+var _ io.Closer = (*ClientConn)(nil)
+
+func (c *ClientConn) Close() error {
+	return c.conn.Close()
+}
+
+func Dial(port int) (*ClientConn, error) {
 	cc, err := grpc.NewClient(
 		fmt.Sprintf("localhost:%d", port),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -18,5 +30,8 @@ func Dial(port int) (pb.ControlClient, error) {
 	if err != nil {
 		return nil, qerr.Transport("control", "dial", err)
 	}
-	return pb.NewControlClient(cc), nil
+	return &ClientConn{
+		ControlClient: pb.NewControlClient(cc),
+		conn:          cc,
+	}, nil
 }

--- a/sink/kafka/config.go
+++ b/sink/kafka/config.go
@@ -2,7 +2,6 @@ package kafka
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	qerr "quanta/internal/errors"
@@ -55,7 +54,7 @@ func (c *Config) validateAndDefault() error {
 	switch c.Acks {
 	case _acksNone, _acksLocal, _acksAll:
 	default:
-		return qerr.Config("kafka-sink", "validate", fmt.Errorf("invalid acks %q (want: none|local|all)", c.Acks))
+		return qerr.Config("kafka-sink", "validate", errors.New("unsupported acks value"))
 	}
 	if c.Compression == "" {
 		c.Compression = _compressionNone
@@ -63,7 +62,7 @@ func (c *Config) validateAndDefault() error {
 	switch c.Compression {
 	case "none", "gzip", "snappy", "lz4", "zstd":
 	default:
-		return qerr.Config("kafka-sink", "validate", fmt.Errorf("invalid compression %q", c.Compression))
+		return qerr.Config("kafka-sink", "validate", errors.New("unsupported compression"))
 	}
 	if c.Timeout <= 0 {
 		c.Timeout = _defaultTimeout

--- a/sink/kafka/driver_sarama.go
+++ b/sink/kafka/driver_sarama.go
@@ -16,12 +16,18 @@ import (
 type SaramaSink struct {
 	cfg    Config
 	prod   sarama.AsyncProducer
+	ack    sink.EmitFn
 	doneCh chan struct{}
 }
 
-var _ sink.Adapter = (*SaramaSink)(nil)
+var (
+	_ sink.Adapter  = (*SaramaSink)(nil)
+	_ sink.AckAware = (*SaramaSink)(nil)
+)
 
-type delivery struct{ ch chan error }
+type inflight struct {
+	checkpoint *pb.CheckpointToken
+}
 
 func (s *SaramaSink) Configure(_ context.Context, raw any) error {
 	var cfg Config
@@ -117,6 +123,10 @@ func buildSaramaConfig(cfg Config) (*sarama.Config, error) {
 	return sc, nil
 }
 
+func (s *SaramaSink) BindAck(fn sink.EmitFn) {
+	s.ack = fn
+}
+
 func (s *SaramaSink) Publish(ctx context.Context, f *pb.Frame) error {
 	if s.prod == nil {
 		return qerr.Sink("kafka", "publish", errors.New("not configured"))
@@ -136,18 +146,12 @@ func (s *SaramaSink) Publish(ctx context.Context, f *pb.Frame) error {
 		Value:     sarama.ByteEncoder(bytes.Clone(f.GetValue())),
 		Timestamp: tsOrNow(f),
 		Headers:   toRecordHeaders(f.GetHeaders()),
+		Metadata:  &inflight{checkpoint: f.Checkpoint},
 	}
-	d := &delivery{ch: make(chan error, 1)}
-	msg.Metadata = d
 
 	select {
 	case s.prod.Input() <- msg:
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-	select {
-	case err := <-d.ch:
-		return err
+		return nil
 	case <-ctx.Done():
 		return ctx.Err()
 	}
@@ -171,26 +175,22 @@ func (s *SaramaSink) pump() {
 				s.flushErrors()
 				return
 			}
-			if d, _ := pm.Metadata.(*delivery); d != nil {
-				select {
-				case d.ch <- nil:
-				default:
-				}
-			}
+			s.ackFromMetadata(pm.Metadata)
 		case pe, ok := <-s.prod.Errors():
 			if !ok {
 				s.flushSuccesses()
 				return
 			}
 			if pe != nil {
-				if d, _ := pe.Msg.Metadata.(*delivery); d != nil {
-					select {
-					case d.ch <- pe.Err:
-					default:
-					}
-				}
+				s.ackFromMetadata(pe.Msg.Metadata)
 			}
 		}
+	}
+}
+
+func (s *SaramaSink) ackFromMetadata(meta any) {
+	if inf, _ := meta.(*inflight); inf != nil && s.ack != nil {
+		s.ack(inf.checkpoint)
 	}
 }
 
@@ -202,12 +202,7 @@ func (s *SaramaSink) flushErrors() {
 				return
 			}
 			if pe != nil {
-				if d, _ := pe.Msg.Metadata.(*delivery); d != nil {
-					select {
-					case d.ch <- pe.Err:
-					default:
-					}
-				}
+				s.ackFromMetadata(pe.Msg.Metadata)
 			}
 		default:
 			return
@@ -222,12 +217,7 @@ func (s *SaramaSink) flushSuccesses() {
 			if !ok {
 				return
 			}
-			if d, _ := pm.Metadata.(*delivery); d != nil {
-				select {
-				case d.ch <- nil:
-				default:
-				}
-			}
+			s.ackFromMetadata(pm.Metadata)
 		default:
 			return
 		}

--- a/sink/kafka/driver_sarama.go
+++ b/sink/kafka/driver_sarama.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"time"
 
 	pb "quanta/api/proto/v1"
@@ -181,8 +182,11 @@ func (s *SaramaSink) pump() {
 				s.flushSuccesses()
 				return
 			}
-			if pe != nil {
-				s.ackFromMetadata(pe.Msg.Metadata)
+			if pe != nil && pe.Msg != nil {
+				slog.Error("kafka-sink: produce failed, withholding ack for redelivery",
+					"topic", pe.Msg.Topic,
+					"err", pe.Err,
+				)
 			}
 		}
 	}
@@ -201,8 +205,11 @@ func (s *SaramaSink) flushErrors() {
 			if !ok {
 				return
 			}
-			if pe != nil {
-				s.ackFromMetadata(pe.Msg.Metadata)
+			if pe != nil && pe.Msg != nil {
+				slog.Error("kafka-sink: produce failed, withholding ack for redelivery",
+					"topic", pe.Msg.Topic,
+					"err", pe.Err,
+				)
 			}
 		default:
 			return

--- a/sink/kafka/driver_sarama_test.go
+++ b/sink/kafka/driver_sarama_test.go
@@ -1,0 +1,305 @@
+package kafka
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	pb "quanta/api/proto/v1"
+	"quanta/sink"
+
+	"github.com/IBM/sarama"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+type fakeAsyncProducer struct {
+	inputCh    chan *sarama.ProducerMessage
+	successCh  chan *sarama.ProducerMessage
+	errorCh    chan *sarama.ProducerError
+	closeCh    chan struct{}
+	closeOnce  sync.Once
+	txnStatus  sarama.ProducerTxnStatusFlag
+	isTransact bool
+}
+
+func newFakeAsyncProducer() *fakeAsyncProducer {
+	return &fakeAsyncProducer{
+		inputCh:   make(chan *sarama.ProducerMessage, 16),
+		successCh: make(chan *sarama.ProducerMessage, 16),
+		errorCh:   make(chan *sarama.ProducerError, 16),
+		closeCh:   make(chan struct{}),
+	}
+}
+
+func (f *fakeAsyncProducer) Input() chan<- *sarama.ProducerMessage     { return f.inputCh }
+func (f *fakeAsyncProducer) Successes() <-chan *sarama.ProducerMessage { return f.successCh }
+func (f *fakeAsyncProducer) Errors() <-chan *sarama.ProducerError      { return f.errorCh }
+func (f *fakeAsyncProducer) IsTransactional() bool                     { return f.isTransact }
+func (f *fakeAsyncProducer) TxnStatus() sarama.ProducerTxnStatusFlag   { return f.txnStatus }
+func (f *fakeAsyncProducer) BeginTxn() error                           { return nil }
+func (f *fakeAsyncProducer) CommitTxn() error                          { return nil }
+func (f *fakeAsyncProducer) AbortTxn() error                           { return nil }
+func (f *fakeAsyncProducer) AddOffsetsToTxn(map[string][]*sarama.PartitionOffsetMetadata, string) error {
+	return nil
+}
+
+func (f *fakeAsyncProducer) AddMessageToTxn(*sarama.ConsumerMessage, string, *string) error {
+	return nil
+}
+
+func (f *fakeAsyncProducer) Close() error {
+	f.AsyncClose()
+	return nil
+}
+
+func (f *fakeAsyncProducer) AsyncClose() {
+	f.closeOnce.Do(func() {
+		close(f.successCh)
+		close(f.errorCh)
+		close(f.closeCh)
+	})
+}
+
+func newTestSink(fp *fakeAsyncProducer) *SaramaSink {
+	s := &SaramaSink{
+		cfg:    Config{Topic: "test-topic"},
+		prod:   fp,
+		doneCh: make(chan struct{}),
+	}
+	go s.pump()
+	return s
+}
+
+func kafkaCheckpoint(topic string, partition int32, offset int64) *pb.CheckpointToken {
+	return &pb.CheckpointToken{
+		Kind: &pb.CheckpointToken_Kafka{
+			Kafka: &pb.KafkaOffset{
+				Topic:     topic,
+				Partition: partition,
+				Offset:    offset,
+			},
+		},
+	}
+}
+
+func testFrame(key, value string, tok *pb.CheckpointToken) *pb.Frame {
+	return &pb.Frame{
+		Key:        []byte(key),
+		Value:      []byte(value),
+		Checkpoint: tok,
+	}
+}
+
+func TestSaramaSink_CompileTimeChecks(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	var _ sink.Adapter = (*SaramaSink)(nil)
+	var _ sink.AckAware = (*SaramaSink)(nil)
+}
+
+func TestSaramaSink_Publish_Enqueues(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	fp := newFakeAsyncProducer()
+	s := newTestSink(fp)
+	defer func() {
+		fp.AsyncClose()
+		<-s.doneCh
+	}()
+
+	tok := kafkaCheckpoint("src", 0, 42)
+	err := s.Publish(context.Background(), testFrame("k", "v", tok))
+	require.NoError(t, err)
+
+	msg := <-fp.inputCh
+	assert.Equal(t, "test-topic", msg.Topic)
+	inf, ok := msg.Metadata.(*inflight)
+	require.True(t, ok)
+	assert.Equal(t, tok, inf.checkpoint)
+}
+
+func TestSaramaSink_Publish_ContextCancelled(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	fp := newFakeAsyncProducer()
+	fp.inputCh = make(chan *sarama.ProducerMessage)
+	s := newTestSink(fp)
+	defer func() {
+		fp.AsyncClose()
+		<-s.doneCh
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := s.Publish(ctx, testFrame("k", "v", kafkaCheckpoint("src", 0, 1)))
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestSaramaSink_Publish_NilProducer(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	s := &SaramaSink{}
+	err := s.Publish(context.Background(), testFrame("k", "v", nil))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not configured")
+}
+
+func TestSaramaSink_Publish_NoTopic(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	fp := newFakeAsyncProducer()
+	s := &SaramaSink{
+		cfg:    Config{},
+		prod:   fp,
+		doneCh: make(chan struct{}),
+	}
+	go s.pump()
+	defer func() {
+		fp.AsyncClose()
+		<-s.doneCh
+	}()
+
+	err := s.Publish(context.Background(), testFrame("k", "v", nil))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no topic resolved")
+}
+
+func TestSaramaSink_PumpAcksOnSuccess(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	fp := newFakeAsyncProducer()
+	s := newTestSink(fp)
+
+	var acked atomic.Int32
+	var ackedTok atomic.Value
+	s.BindAck(func(tok *pb.CheckpointToken) {
+		acked.Add(1)
+		ackedTok.Store(tok)
+	})
+
+	tok := kafkaCheckpoint("src", 0, 100)
+	err := s.Publish(context.Background(), testFrame("k", "v", tok))
+	require.NoError(t, err)
+
+	msg := <-fp.inputCh
+	fp.successCh <- msg
+
+	fp.AsyncClose()
+	<-s.doneCh
+
+	assert.Equal(t, int32(1), acked.Load())
+	assert.Equal(t, tok, ackedTok.Load())
+}
+
+func TestSaramaSink_PumpAcksOnError(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	fp := newFakeAsyncProducer()
+	s := newTestSink(fp)
+
+	var acked atomic.Int32
+	s.BindAck(func(tok *pb.CheckpointToken) {
+		acked.Add(1)
+	})
+
+	tok := kafkaCheckpoint("src", 0, 200)
+	err := s.Publish(context.Background(), testFrame("k", "v", tok))
+	require.NoError(t, err)
+
+	msg := <-fp.inputCh
+	fp.errorCh <- &sarama.ProducerError{
+		Msg: msg,
+		Err: sarama.ErrOutOfBrokers,
+	}
+
+	fp.AsyncClose()
+	<-s.doneCh
+
+	assert.Equal(t, int32(1), acked.Load())
+}
+
+func TestSaramaSink_PumpDrainsAllInFlight(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	fp := newFakeAsyncProducer()
+	s := newTestSink(fp)
+
+	var acked atomic.Int32
+	s.BindAck(func(_ *pb.CheckpointToken) { acked.Add(1) })
+
+	const n = 5
+	for i := range n {
+		tok := kafkaCheckpoint("src", 0, int64(i))
+		require.NoError(t, s.Publish(context.Background(), testFrame("k", "v", tok)))
+	}
+
+	for range n {
+		msg := <-fp.inputCh
+		if msg.Offset%2 == 0 {
+			fp.successCh <- msg
+		} else {
+			fp.errorCh <- &sarama.ProducerError{Msg: msg, Err: sarama.ErrOutOfBrokers}
+		}
+	}
+
+	fp.AsyncClose()
+	<-s.doneCh
+
+	assert.Equal(t, int32(n), acked.Load())
+}
+
+func TestSaramaSink_Close_WaitsPump(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	fp := newFakeAsyncProducer()
+	s := newTestSink(fp)
+
+	err := s.Close(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, s.prod)
+}
+
+func TestSaramaSink_Close_NilProducer(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	s := &SaramaSink{}
+	err := s.Close(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestSaramaSink_BindAck(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	s := &SaramaSink{}
+	var called bool
+	s.BindAck(func(_ *pb.CheckpointToken) { called = true })
+	require.NotNil(t, s.ack)
+	s.ack(nil)
+	assert.True(t, called)
+}
+
+func TestSaramaSink_HeaderTopicOverride(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	fp := newFakeAsyncProducer()
+	s := &SaramaSink{
+		cfg:    Config{Topic: "default-topic", HeaderTopicKey: "X-Target"},
+		prod:   fp,
+		doneCh: make(chan struct{}),
+	}
+	go s.pump()
+	defer func() {
+		fp.AsyncClose()
+		<-s.doneCh
+	}()
+
+	f := &pb.Frame{
+		Key:   []byte("k"),
+		Value: []byte("v"),
+		Headers: map[string][]byte{
+			"X-Target": []byte("override-topic"),
+		},
+	}
+
+	require.NoError(t, s.Publish(context.Background(), f))
+	msg := <-fp.inputCh
+	assert.Equal(t, "override-topic", msg.Topic)
+}

--- a/sink/kafka/driver_sarama_test.go
+++ b/sink/kafka/driver_sarama_test.go
@@ -191,7 +191,7 @@ func TestSaramaSink_PumpAcksOnSuccess(t *testing.T) {
 	assert.Equal(t, tok, ackedTok.Load())
 }
 
-func TestSaramaSink_PumpAcksOnError(t *testing.T) {
+func TestSaramaSink_PumpWithholdsAckOnError(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
 	fp := newFakeAsyncProducer()
@@ -215,7 +215,7 @@ func TestSaramaSink_PumpAcksOnError(t *testing.T) {
 	fp.AsyncClose()
 	<-s.doneCh
 
-	assert.Equal(t, int32(1), acked.Load())
+	assert.Equal(t, int32(0), acked.Load())
 }
 
 func TestSaramaSink_PumpDrainsAllInFlight(t *testing.T) {
@@ -245,7 +245,8 @@ func TestSaramaSink_PumpDrainsAllInFlight(t *testing.T) {
 	fp.AsyncClose()
 	<-s.doneCh
 
-	assert.Equal(t, int32(n), acked.Load())
+	// Only successes (i=0,2,4) get acked; errors are withheld.
+	assert.Equal(t, int32(3), acked.Load())
 }
 
 func TestSaramaSink_Close_WaitsPump(t *testing.T) {

--- a/sink/kafka/driver_sarama_test.go
+++ b/sink/kafka/driver_sarama_test.go
@@ -233,9 +233,9 @@ func TestSaramaSink_PumpDrainsAllInFlight(t *testing.T) {
 		require.NoError(t, s.Publish(context.Background(), testFrame("k", "v", tok)))
 	}
 
-	for range n {
+	for i := range n {
 		msg := <-fp.inputCh
-		if msg.Offset%2 == 0 {
+		if i%2 == 0 {
 			fp.successCh <- msg
 		} else {
 			fp.errorCh <- &sarama.ProducerError{Msg: msg, Err: sarama.ErrOutOfBrokers}

--- a/sink/s3/config.go
+++ b/sink/s3/config.go
@@ -2,7 +2,6 @@ package s3
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	qerr "quanta/internal/errors"
@@ -80,7 +79,7 @@ func (c *Config) validate() error {
 	case AuthIAMRole, AuthEnvVars:
 
 	default:
-		return qerr.Config("s3", "validate", fmt.Errorf("invalid auth_strategy: %s", c.AuthStrategy))
+		return qerr.Config("s3", "validate", errors.New("unsupported auth_strategy"))
 	}
 
 	return nil

--- a/sink/s3/driver.go
+++ b/sink/s3/driver.go
@@ -21,7 +21,6 @@ import (
 	"quanta/sink"
 )
 
-// Client abstracts the S3 API surface needed by Driver.
 type Client interface {
 	PutObject(ctx context.Context, params *s3svc.PutObjectInput, optFns ...func(*s3svc.Options)) (*s3svc.PutObjectOutput, error)
 }
@@ -31,9 +30,6 @@ var (
 	_ sink.AckAware = (*Driver)(nil)
 )
 
-// Driver implements sink.Adapter and sink.AckAware for Amazon S3.
-// It batches records, encodes them via a pluggable Encoder, uploads to S3,
-// and acks checkpoint tokens only after a successful upload.
 type Driver struct {
 	cfg     Config
 	client  Client
@@ -43,14 +39,12 @@ type Driver struct {
 
 	mu      sync.Mutex
 	current *batch
-	sealCh  chan *batch // sealed full batches ready for upload
+	sealCh  chan *batch
 	stopCh  chan struct{}
 	doneCh  chan struct{}
 	cancel  context.CancelFunc
 }
 
-// Configure initialises the S3 client, encoder, batch pool and starts the
-// background flush goroutine.
 func (d *Driver) Configure(ctx context.Context, raw any) error {
 	var cfg Config
 	switch v := raw.(type) {
@@ -85,9 +79,6 @@ func (d *Driver) Configure(ctx context.Context, raw any) error {
 
 	pool := newBatchPool(cfg.BatchSize)
 
-	// Derive a cancellable context that inherits values (tracing, logging)
-	// but does not cancel when the parent does.  The cancel func is stored
-	// so Close can interrupt hung PutObject calls.
 	flushCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 
 	d.cfg = cfg
@@ -123,9 +114,6 @@ func (d *Driver) Publish(_ context.Context, f *pb.Frame) error {
 	return nil
 }
 
-// Close signals the flush goroutine to drain remaining batches, waits
-// for it to finish, then cancels the flush context so any hung PutObject
-// calls are interrupted.
 func (d *Driver) Close(ctx context.Context) error {
 	close(d.stopCh)
 	select {
@@ -153,7 +141,7 @@ func newS3Client(ctx context.Context, cfg *Config) (*s3svc.Client, error) {
 			credentials.NewStaticCredentialsProvider(cfg.AccessKeyID, cfg.SecretAccessKey, ""),
 		))
 	case AuthIAMRole, AuthEnvVars:
-		// Default credential chain handles these.
+		// use default credentials
 	}
 
 	ac, err := awscfg.LoadDefaultConfig(ctx, opts...)
@@ -216,8 +204,6 @@ func (d *Driver) flushPartial(ctx context.Context) {
 	d.uploadBatch(ctx, partial)
 }
 
-// uploadBatch encodes a batch, uploads to S3, and acks checkpoint tokens
-// on success.
 func (d *Driver) uploadBatch(ctx context.Context, b *batch) {
 	records := b.records[:b.len()]
 	checkpoints := b.checkpoints[:b.len()]
@@ -225,6 +211,7 @@ func (d *Driver) uploadBatch(ctx context.Context, b *batch) {
 	data, err := d.encoder.Encode(records)
 	if err != nil {
 		logging.L().WarnContext(ctx, "s3 sink: encode", "error", err)
+		d.ackAll(checkpoints)
 		d.recycleBatch(b)
 		return
 	}
@@ -239,20 +226,24 @@ func (d *Driver) uploadBatch(ctx context.Context, b *batch) {
 	})
 	if err != nil {
 		logging.L().WarnContext(ctx, "s3 sink: upload", "error", err, "key", key)
+		d.ackAll(checkpoints)
 		d.recycleBatch(b)
 		return
 	}
 
-	if d.ack != nil {
-		for _, tok := range checkpoints {
-			d.ack(tok)
-		}
-	}
-
+	d.ackAll(checkpoints)
 	d.recycleBatch(b)
 }
 
-// objectKey builds a slash-safe S3 key from the configured prefix.
+func (d *Driver) ackAll(checkpoints []*pb.CheckpointToken) {
+	if d.ack == nil {
+		return
+	}
+	for _, tok := range checkpoints {
+		d.ack(tok)
+	}
+}
+
 func (d *Driver) objectKey() string {
 	name := fmt.Sprintf("%d_data%s", time.Now().UnixNano(), d.cfg.FileSuffix)
 	prefix := strings.TrimRight(d.cfg.Prefix, "/")

--- a/sink/s3/driver.go
+++ b/sink/s3/driver.go
@@ -210,8 +210,8 @@ func (d *Driver) uploadBatch(ctx context.Context, b *batch) {
 
 	data, err := d.encoder.Encode(records)
 	if err != nil {
-		logging.L().WarnContext(ctx, "s3 sink: encode", "error", err)
-		d.ackAll(checkpoints)
+		logging.L().ErrorContext(ctx, "s3 sink: encode failed, withholding ack for redelivery",
+			"error", err, "frames", len(records))
 		d.recycleBatch(b)
 		return
 	}
@@ -225,8 +225,8 @@ func (d *Driver) uploadBatch(ctx context.Context, b *batch) {
 		ContentType: aws.String(d.encoder.ContentType()),
 	})
 	if err != nil {
-		logging.L().WarnContext(ctx, "s3 sink: upload", "error", err, "key", key)
-		d.ackAll(checkpoints)
+		logging.L().ErrorContext(ctx, "s3 sink: upload failed, withholding ack for redelivery",
+			"error", err, "key", key, "frames", len(records))
 		d.recycleBatch(b)
 		return
 	}

--- a/sink/s3/driver_test.go
+++ b/sink/s3/driver_test.go
@@ -3,8 +3,10 @@ package s3
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -245,6 +247,33 @@ func TestDriverClonesSafely(t *testing.T) {
 func TestDriverImplementsInterfaces(t *testing.T) {
 	var _ sink.Adapter = (*Driver)(nil)
 	var _ sink.AckAware = (*Driver)(nil)
+}
+
+func TestDriverUploadError_WithholdsAck(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	spy := &spyClient{err: errors.New("S3 unavailable")}
+	d := newTestDriver(t, spy)
+	defer d.Close(context.Background())
+
+	var acked atomic.Int32
+	d.BindAck(func(_ *pb.CheckpointToken) { acked.Add(1) })
+
+	ctx := context.Background()
+	for i := range 3 {
+		tok := &pb.CheckpointToken{Kind: &pb.CheckpointToken_Kafka{
+			Kafka: &pb.KafkaOffset{Offset: int64(i)},
+		}}
+		require.NoError(t, d.Publish(ctx, &pb.Frame{Value: []byte("x"), Checkpoint: tok}))
+	}
+
+	require.Eventually(t, func() bool {
+		spy.mu.Lock()
+		defer spy.mu.Unlock()
+		return len(spy.calls) == 1
+	}, 2*time.Second, 10*time.Millisecond, "expected PutObject call")
+
+	assert.Equal(t, int32(0), acked.Load(), "ack must be withheld on upload failure")
 }
 
 func newTestDriver(t *testing.T, spy *spyClient) *Driver {

--- a/sink/s3/encoder.go
+++ b/sink/s3/encoder.go
@@ -2,23 +2,21 @@ package s3
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 )
 
-// Encoder serializes a slice of raw records into a single body for S3 upload.
 type Encoder interface {
 	Encode(records [][]byte) ([]byte, error)
 	ContentType() string
 }
 
-// jsonlEncoder encodes records as newline-delimited JSON (JSON Lines / NDJSON).
 type jsonlEncoder struct{}
 
 func (jsonlEncoder) Encode(records [][]byte) ([]byte, error) {
 	if len(records) == 0 {
 		return nil, nil
 	}
-	// JSONL spec: each record on its own line, terminated by \n.
+
 	joined := bytes.Join(records, []byte("\n"))
 	joined = append(joined, '\n')
 	return joined, nil
@@ -31,6 +29,6 @@ func newEncoder(name string) (Encoder, error) {
 	case "jsonl":
 		return jsonlEncoder{}, nil
 	default:
-		return nil, fmt.Errorf("unsupported format %q", name)
+		return nil, errors.New("unsupported encoder format")
 	}
 }

--- a/source/kafka/ackwindow.go
+++ b/source/kafka/ackwindow.go
@@ -4,7 +4,6 @@ import (
 	"math"
 	"math/bits"
 	"sync"
-	"sync/atomic"
 )
 
 const (
@@ -39,26 +38,24 @@ func (p *PartitionTracker) Reset(base int64) {
 	for i := range p.window {
 		p.window[i] = 0
 	}
-	atomic.StoreInt64(&p.base, base)
+	p.base = base
 	p.initialized = true
 }
 
 func (p *PartitionTracker) Reserve(offset int64) uint32 {
-	if !p.Initialized() {
-		p.mu.Lock()
-		if !p.initialized {
-			atomic.StoreInt64(&p.base, offset)
-			p.initialized = true
-			for i := range p.window {
-				p.window[i] = 0
-			}
-			p.mu.Unlock()
-			return 0
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if !p.initialized {
+		p.base = offset
+		p.initialized = true
+		for i := range p.window {
+			p.window[i] = 0
 		}
-		p.mu.Unlock()
+		return 0
 	}
-	base := atomic.LoadInt64(&p.base)
-	delta := offset - base
+
+	delta := offset - p.base
 	if delta < 0 || delta > math.MaxUint32 {
 		return InvalidSlot
 	}
@@ -75,13 +72,12 @@ func (p *PartitionTracker) AckOffset(offset int64) (int64, bool) {
 	if !p.initialized {
 		return p.base, false
 	}
-	base := atomic.LoadInt64(&p.base)
-	if offset < base {
-		return base, false
+	if offset < p.base {
+		return p.base, false
 	}
-	delta := offset - base
+	delta := offset - p.base
 	if delta >= int64(p.size) || delta < 0 {
-		return base, false
+		return p.base, false
 	}
 	slot := uint32(delta) //nolint:gosec // bounds-checked above: 0 <= delta < p.size (uint32)
 	word := slot / _bitsPerWord
@@ -90,19 +86,21 @@ func (p *PartitionTracker) AckOffset(offset int64) (int64, bool) {
 	oldWord := p.window[word]
 	mask := uint64(1) << bit
 	if oldWord&mask != 0 {
-		return base, false
+		return p.base, false
 	}
 
 	p.window[word] |= mask
-	newBase, advanced := p.advanceLocked(base)
+	newBase, advanced := p.advanceLocked(p.base)
 	if advanced {
-		atomic.StoreInt64(&p.base, newBase)
+		p.base = newBase
 	}
 	return newBase, advanced
 }
 
 func (p *PartitionTracker) Base() int64 {
-	return atomic.LoadInt64(&p.base)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.base
 }
 
 func (p *PartitionTracker) Initialized() bool {
@@ -123,7 +121,7 @@ func (p *PartitionTracker) advanceLocked(current int64) (int64, bool) {
 			return base, advanced
 		}
 		advanced = true
-		shift := uint(run) //nolint:gosec // run is 0..64 from TrailingZeros64
+		shift := uint(run) //nolint:gosec // run is from TrailingZeros64: [0, 64]
 		var carry uint64
 		for i := len(p.window) - 1; i >= 0; i-- {
 			next := p.window[i] << (_bitsPerWord - shift)
@@ -133,6 +131,6 @@ func (p *PartitionTracker) advanceLocked(current int64) (int64, bool) {
 				break
 			}
 		}
-		base += int64(shift) //nolint:gosec // shift is 0..64, fits int64
+		base += int64(shift) //nolint:gosec // shift ≤ 64, fits int64
 	}
 }

--- a/source/kafka/backpressure_manager_test.go
+++ b/source/kafka/backpressure_manager_test.go
@@ -7,48 +7,168 @@ import (
 	"time"
 )
 
-func TestCountBasedBackpressureIgnoresSize(t *testing.T) {
-	mgr := NewCountBasedBackpressureManager(2)
+func TestBackpressureManager_AcquireRelease(t *testing.T) {
+	t.Parallel()
 
-	if err := mgr.Acquire(context.Background(), 128); err != nil {
-		t.Fatalf("first acquire failed: %v", err)
-	}
-	if err := mgr.Acquire(context.Background(), 256); err != nil {
-		t.Fatalf("second acquire failed: %v", err)
+	tests := []struct {
+		name        string
+		newMgr      func() BackpressureManager
+		acquireSize int64
+		acquireN    int
+		wantBlock   bool
+	}{
+		{
+			name:        "count_based_within_limit",
+			newMgr:      func() BackpressureManager { return NewCountBasedBackpressureManager(3) },
+			acquireSize: 999,
+			acquireN:    3,
+			wantBlock:   false,
+		},
+		{
+			name:        "count_based_exceeds_limit",
+			newMgr:      func() BackpressureManager { return NewCountBasedBackpressureManager(2) },
+			acquireSize: 1,
+			acquireN:    3,
+			wantBlock:   true,
+		},
+		{
+			name:        "size_based_within_limit",
+			newMgr:      func() BackpressureManager { return NewSizeBasedBackpressureManager(100) },
+			acquireSize: 30,
+			acquireN:    3,
+			wantBlock:   false,
+		},
+		{
+			name:        "size_based_exceeds_limit",
+			newMgr:      func() BackpressureManager { return NewSizeBasedBackpressureManager(50) },
+			acquireSize: 30,
+			acquireN:    2,
+			wantBlock:   true,
+		},
+		{
+			name:        "combined_within_both_limits",
+			newMgr:      func() BackpressureManager { return NewCombinedBackpressureManager(100, 3) },
+			acquireSize: 20,
+			acquireN:    3,
+			wantBlock:   false,
+		},
+		{
+			name:        "combined_msg_limit_hit",
+			newMgr:      func() BackpressureManager { return NewCombinedBackpressureManager(1000, 1) },
+			acquireSize: 10,
+			acquireN:    2,
+			wantBlock:   true,
+		},
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
-	defer cancel()
-	if err := mgr.Acquire(ctx, 1); !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("expected deadline exceeded, got %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	mgr.Release(0)
-	mgr.Release(0)
+			mgr := tt.newMgr()
 
-	if err := mgr.Acquire(context.Background(), 1); err != nil {
-		t.Fatalf("acquire after release failed: %v", err)
+			for i := 0; i < tt.acquireN-1; i++ {
+				if err := mgr.Acquire(context.Background(), tt.acquireSize); err != nil {
+					t.Fatalf("Acquire[%d]: %v", i, err)
+				}
+			}
+
+			if !tt.wantBlock {
+				if err := mgr.Acquire(context.Background(), tt.acquireSize); err != nil {
+					t.Fatalf("final Acquire: %v", err)
+				}
+				for i := 0; i < tt.acquireN; i++ {
+					mgr.Release(tt.acquireSize)
+				}
+				return
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+			defer cancel()
+
+			err := mgr.Acquire(ctx, tt.acquireSize)
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("expected DeadlineExceeded, got: %v", err)
+			}
+
+			for i := 0; i < tt.acquireN-1; i++ {
+				mgr.Release(tt.acquireSize)
+			}
+
+			if err := mgr.Acquire(context.Background(), tt.acquireSize); err != nil {
+				t.Fatalf("Acquire after release: %v", err)
+			}
+			mgr.Release(tt.acquireSize)
+		})
 	}
-	mgr.Release(1)
 }
 
-func TestCombinedBackpressureEnforcesMessageLimit(t *testing.T) {
-	mgr := NewCombinedBackpressureManager(100, 1)
+func TestBackpressureManager_Capacity(t *testing.T) {
+	t.Parallel()
 
-	if err := mgr.Acquire(context.Background(), 20); err != nil {
-		t.Fatalf("first acquire failed: %v", err)
+	tests := []struct {
+		name    string
+		mgr     BackpressureManager
+		wantCap int64
+	}{
+		{
+			name:    "count_based_default",
+			mgr:     NewCountBasedBackpressureManager(0),
+			wantCap: 1000,
+		},
+		{
+			name:    "count_based_explicit",
+			mgr:     NewCountBasedBackpressureManager(42),
+			wantCap: 42,
+		},
+		{
+			name:    "size_based_default",
+			mgr:     NewSizeBasedBackpressureManager(0),
+			wantCap: _defaultMaxBytes,
+		},
+		{
+			name:    "size_based_explicit",
+			mgr:     NewSizeBasedBackpressureManager(1024),
+			wantCap: 1024,
+		},
+		{
+			name:    "combined_returns_byte_cap",
+			mgr:     NewCombinedBackpressureManager(2048, 100),
+			wantCap: 2048,
+		},
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
-	defer cancel()
-	if err := mgr.Acquire(ctx, 30); !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("expected deadline exceeded waiting on message tokens, got %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.mgr.Capacity(); got != tt.wantCap {
+				t.Fatalf("Capacity: got %d, want %d", got, tt.wantCap)
+			}
+		})
+	}
+}
+
+func TestBackpressureManager_ZeroSizeNormalisedToOne(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mgr  BackpressureManager
+	}{
+		{"size_based", NewSizeBasedBackpressureManager(10)},
+		{"combined", NewCombinedBackpressureManager(10, 10)},
 	}
 
-	mgr.Release(20)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	if err := mgr.Acquire(context.Background(), 40); err != nil {
-		t.Fatalf("acquire after release failed: %v", err)
+			if err := tt.mgr.Acquire(context.Background(), 0); err != nil {
+				t.Fatalf("Acquire(0): %v", err)
+			}
+
+			tt.mgr.Release(0)
+		})
 	}
-	mgr.Release(40)
 }

--- a/source/kafka/checkpoint_manager.go
+++ b/source/kafka/checkpoint_manager.go
@@ -11,7 +11,11 @@ var ErrCheckpointClosed = errors.New("kafka: checkpoint manager closed")
 const (
 	_defaultCapacity = 1024
 	_spinBackoff     = 200 * time.Microsecond
+	_maxSpinBackoff  = 10 * time.Millisecond
+	_maxSpinAttempts = 500
 )
+
+var ErrWindowExhausted = errors.New("kafka: sliding window exhausted after max attempts")
 
 type SlidingWindowCheckpointManager struct {
 	tracker *PartitionTracker
@@ -35,16 +39,20 @@ func (c *SlidingWindowCheckpointManager) Track(offset int64, size int64) error {
 	if size <= 0 {
 		size = 1
 	}
+
 	backoff := _spinBackoff
-	for {
+	for attempt := 0; attempt < _maxSpinAttempts; attempt++ {
 		if c.tracker.Reserve(offset) != InvalidSlot {
-			break
+			c.acker.Track(offset, AckHandle{offset: offset, bytes: size})
+			return nil
 		}
 		time.Sleep(backoff)
+		backoff *= 2
+		if backoff > _maxSpinBackoff {
+			backoff = _maxSpinBackoff
+		}
 	}
-
-	c.acker.Track(offset, AckHandle{offset: offset, bytes: size})
-	return nil
+	return ErrWindowExhausted
 }
 
 func (c *SlidingWindowCheckpointManager) Ack(offset int64) (AckHandle, int64, bool) {

--- a/source/kafka/checkpoint_manager_test.go
+++ b/source/kafka/checkpoint_manager_test.go
@@ -1,88 +1,252 @@
 package kafka
 
 import (
+	"errors"
 	"testing"
 	"time"
 )
 
-func TestSlidingWindowCheckpointManagerAckReturnsHandle(t *testing.T) {
-	mgr := NewSlidingWindowCheckpointManager(8, 4)
+func TestSlidingWindowCheckpointManager_TrackAndAck(t *testing.T) {
+	t.Parallel()
 
-	if err := mgr.Track(100, 5); err != nil {
-		t.Fatalf("track failed: %v", err)
+	tests := []struct {
+		name        string
+		windowBits  uint32
+		capacity    int
+		trackOffset int64
+		trackSize   int64
+		ackOffset   int64
+		wantHandle  AckHandle
+		wantBase    int64
+		wantAdv     bool
+	}{
+		{
+			name:        "track_then_ack_advances_base",
+			windowBits:  8,
+			capacity:    4,
+			trackOffset: 100,
+			trackSize:   5,
+			ackOffset:   100,
+			wantHandle:  AckHandle{offset: 100, bytes: 5},
+			wantBase:    101,
+			wantAdv:     true,
+		},
+		{
+			name:        "ack_unknown_offset_does_not_advance",
+			windowBits:  8,
+			capacity:    4,
+			trackOffset: 100,
+			trackSize:   5,
+			ackOffset:   500,
+			wantHandle:  AckHandle{},
+			wantBase:    100,
+			wantAdv:     false,
+		},
+		{
+			name:        "zero_size_normalised_to_one",
+			windowBits:  8,
+			capacity:    4,
+			trackOffset: 200,
+			trackSize:   0,
+			ackOffset:   200,
+			wantHandle:  AckHandle{offset: 200, bytes: 1},
+			wantBase:    201,
+			wantAdv:     true,
+		},
 	}
 
-	handle, newBase, advanced := mgr.Ack(100)
-	if handle.offset != 100 {
-		t.Fatalf("unexpected handle offset: got %d want 100", handle.offset)
-	}
-	if handle.bytes != 5 {
-		t.Fatalf("unexpected handle bytes: got %d want 5", handle.bytes)
-	}
-	if !advanced || newBase != 101 {
-		t.Fatalf("expected base 101 advanced=true got base=%d advanced=%v", newBase, advanced)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	emptyHandle, base, adv := mgr.Ack(500)
+			mgr := NewSlidingWindowCheckpointManager(tt.windowBits, tt.capacity)
+			if err := mgr.Track(tt.trackOffset, tt.trackSize); err != nil {
+				t.Fatalf("Track: %v", err)
+			}
 
-	if emptyHandle != (AckHandle{}) {
-		t.Fatalf("expected empty handle for unknown offset, got %+v", emptyHandle)
-	}
-	if adv {
-		t.Fatalf("unexpected advance for unknown offset")
-	}
-	if base != mgr.Base() {
-		t.Fatalf("base should be unchanged for unknown offset")
+			handle, base, adv := mgr.Ack(tt.ackOffset)
+			if handle != tt.wantHandle {
+				t.Fatalf("handle: got %+v, want %+v", handle, tt.wantHandle)
+			}
+			if base != tt.wantBase {
+				t.Fatalf("base: got %d, want %d", base, tt.wantBase)
+			}
+			if adv != tt.wantAdv {
+				t.Fatalf("advanced: got %v, want %v", adv, tt.wantAdv)
+			}
+		})
 	}
 }
 
-func TestApplicationControlledCheckpointManagerBlocksUntilAck(t *testing.T) {
-	mgr := NewApplicationControlledCheckpointManager(1)
+func TestSlidingWindowCheckpointManager_BoundedBackoff(t *testing.T) {
+	t.Parallel()
 
+	tests := []struct {
+		name    string
+		window  uint32
+		fill    int
+		nextOff int64
+		wantErr error
+	}{
+		{
+			name:    "within_window_succeeds",
+			window:  8,
+			fill:    7,
+			nextOff: 7,
+			wantErr: nil,
+		},
+		{
+			name:    "window_full_returns_exhausted",
+			window:  256,
+			fill:    256,
+			nextOff: 256,
+			wantErr: ErrWindowExhausted,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mgr := NewSlidingWindowCheckpointManager(tt.window, tt.fill+1)
+
+			for i := 0; i < tt.fill; i++ {
+				if err := mgr.Track(int64(i), 1); err != nil {
+					t.Fatalf("Track(%d): %v", i, err)
+				}
+			}
+
+			err := mgr.Track(tt.nextOff, 1)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Track(%d): got %v, want %v", tt.nextOff, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestApplicationControlledCheckpointManager_Lifecycle(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		capacity     int64
+		tracks       []int64
+		ackOrder     []int64
+		wantBases    []int64
+		wantAdvanced []bool
+	}{
+		{
+			name:         "sequential_ack_advances_base",
+			capacity:     10,
+			tracks:       []int64{10, 11, 12},
+			ackOrder:     []int64{10, 11, 12},
+			wantBases:    []int64{11, 12, 13},
+			wantAdvanced: []bool{true, true, true},
+		},
+		{
+			name:         "out_of_order_ack_partial_advance",
+			capacity:     10,
+			tracks:       []int64{10, 11, 12},
+			ackOrder:     []int64{12, 11, 10},
+			wantBases:    []int64{10, 10, 11},
+			wantAdvanced: []bool{false, false, true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mgr := NewApplicationControlledCheckpointManager(tt.capacity)
+
+			for _, off := range tt.tracks {
+				if err := mgr.Track(off, 1); err != nil {
+					t.Fatalf("Track(%d): %v", off, err)
+				}
+			}
+
+			for i, off := range tt.ackOrder {
+				_, base, adv := mgr.Ack(off)
+				if base != tt.wantBases[i] {
+					t.Fatalf("Ack(%d): base got %d, want %d", off, base, tt.wantBases[i])
+				}
+				if adv != tt.wantAdvanced[i] {
+					t.Fatalf("Ack(%d): advanced got %v, want %v", off, adv, tt.wantAdvanced[i])
+				}
+			}
+		})
+	}
+}
+
+func TestApplicationControlledCheckpointManager_BlocksUntilAck(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewApplicationControlledCheckpointManager(1)
 	if err := mgr.Track(10, 7); err != nil {
-		t.Fatalf("track failed: %v", err)
+		t.Fatalf("Track: %v", err)
 	}
 
 	done := make(chan struct{})
 	go func() {
 		if err := mgr.Track(11, 9); err != nil {
-			t.Errorf("unexpected track error: %v", err)
+			t.Errorf("Track(11): %v", err)
 		}
 		close(done)
 	}()
 
 	select {
 	case <-done:
-		t.Fatal("second track should block until ack")
+		t.Fatal("second Track should block until ack")
 	case <-time.After(30 * time.Millisecond):
 	}
 
-	handle, base, advanced := mgr.Ack(10)
+	handle, base, adv := mgr.Ack(10)
 	if handle.offset != 10 || handle.bytes != 7 {
-		t.Fatalf("unexpected handle returned: %+v", handle)
+		t.Fatalf("unexpected handle: %+v", handle)
 	}
-	if !advanced || base != 11 {
-		t.Fatalf("expected base 11 advanced=true got base=%d advanced=%v", base, advanced)
+	if !adv || base != 11 {
+		t.Fatalf("expected base=11 advanced=true, got base=%d advanced=%v", base, adv)
 	}
 
 	select {
 	case <-done:
-	case <-time.After(50 * time.Millisecond):
-		t.Fatal("second track did not unblock after ack")
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("second Track should unblock after ack")
 	}
+}
 
-	handle2, base2, advanced2 := mgr.Ack(11)
-	if handle2.offset != 11 || handle2.bytes != 9 {
-		t.Fatalf("unexpected handle from second ack: %+v", handle2)
+func TestApplicationControlledCheckpointManager_ClosedReturnsError(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewApplicationControlledCheckpointManager(10)
+	mgr.Close()
+
+	err := mgr.Track(1, 1)
+	if !errors.Is(err, ErrCheckpointClosed) {
+		t.Fatalf("expected ErrCheckpointClosed, got: %v", err)
 	}
-	if !advanced2 || base2 != 12 {
-		t.Fatalf("expected base 12 advanced=true got base=%d advanced=%v", base2, advanced2)
+}
+
+func TestApplicationControlledCheckpointManager_ResetClearsState(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewApplicationControlledCheckpointManager(10)
+
+	if err := mgr.Track(50, 10); err != nil {
+		t.Fatalf("Track: %v", err)
+	}
+	if err := mgr.Track(51, 20); err != nil {
+		t.Fatalf("Track: %v", err)
 	}
 
 	handles := mgr.Reset()
-	if len(handles) != 0 {
-		t.Fatalf("expected reset to return no handles, got %d", len(handles))
+	if len(handles) != 2 {
+		t.Fatalf("Reset handles: got %d, want 2", len(handles))
 	}
-
-	mgr.Close()
+	if mgr.Initialized() {
+		t.Fatal("expected Initialized=false after Reset")
+	}
+	if mgr.Base() != -1 {
+		t.Fatalf("expected base=-1 after Reset, got %d", mgr.Base())
+	}
 }

--- a/source/kafka/component_factory.go
+++ b/source/kafka/component_factory.go
@@ -1,7 +1,7 @@
 package kafka
 
 import (
-	"fmt"
+	"errors"
 	"log/slog"
 
 	qerr "quanta/internal/errors"
@@ -46,7 +46,7 @@ func NewBackpressureManager(cfg Config) (BackpressureManager, error) {
 	case BackpressureStrategyCombined:
 		return NewCombinedBackpressureManager(tun.InFlightBytes, tun.InFlightMsgs), nil
 	default:
-		return nil, qerr.Config("kafka", "backpressure", fmt.Errorf("unknown strategy: %s", strategy))
+		return nil, qerr.Config("kafka", "backpressure", errors.New("unsupported backpressure strategy"))
 	}
 }
 
@@ -64,7 +64,7 @@ func NewCheckpointManager(cfg Config) (CheckpointManager, error) {
 	case CheckpointStrategyApplicationControlled:
 		return NewApplicationControlledCheckpointManager(tun.InFlightMsgs), nil
 	default:
-		return nil, qerr.Config("kafka", "checkpoint", fmt.Errorf("unknown strategy: %s", strategy))
+		return nil, qerr.Config("kafka", "checkpoint", errors.New("unsupported checkpoint strategy"))
 	}
 }
 
@@ -84,6 +84,6 @@ func NewCommitStrategy(cfg Config, logger *slog.Logger) (CommitStrategy, error) 
 	case CommitStrategyTypeHybrid:
 		return NewHybridCommitStrategy(int64(tun.CommitStep), tun.CommitInterval, logger), nil
 	default:
-		return nil, qerr.Config("kafka", "commit", fmt.Errorf("unknown strategy: %s", strategy))
+		return nil, qerr.Config("kafka", "commit", errors.New("unsupported commit strategy"))
 	}
 }

--- a/source/kafka/config.go
+++ b/source/kafka/config.go
@@ -1,7 +1,7 @@
 package kafka
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,8 +13,6 @@ import (
 	"github.com/knadh/koanf/providers/env"
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/v2"
-
-	stderrors "errors"
 )
 
 type CommitMode string
@@ -112,7 +110,7 @@ func loadTuningConfig(publicPath string) (Tuning, error) {
 				if err := k.Load(file.Provider(tuningPath), yaml.Parser()); err != nil {
 					return Tuning{}, err
 				}
-			} else if !stderrors.Is(err, os.ErrNotExist) {
+			} else if !errors.Is(err, os.ErrNotExist) {
 				return Tuning{}, err
 			}
 		}
@@ -181,23 +179,23 @@ func applyPublicDefaults(c *PublicConfig) {
 
 func validatePublic(c PublicConfig) error {
 	if len(c.Brokers) == 0 {
-		return qerr.Config("kafka", "validate", stderrors.New("brokers required"))
+		return qerr.Config("kafka", "validate", errors.New("brokers required"))
 	}
 	if len(c.Topics) == 0 {
-		return qerr.Config("kafka", "validate", stderrors.New("topics required"))
+		return qerr.Config("kafka", "validate", errors.New("topics required"))
 	}
 	if c.GroupID == "" {
-		return qerr.Config("kafka", "validate", stderrors.New("group_id required"))
+		return qerr.Config("kafka", "validate", errors.New("group_id required"))
 	}
 	switch c.CommitMode {
 	case CommitAuto, CommitE2E:
 	default:
-		return qerr.Config("kafka", "validate", fmt.Errorf("invalid commit_mode %q", c.CommitMode))
+		return qerr.Config("kafka", "validate", errors.New("unsupported commit_mode"))
 	}
 	switch c.StartFrom {
 	case "oldest", "newest":
 	default:
-		return qerr.Config("kafka", "validate", fmt.Errorf("invalid start_from %q", c.StartFrom))
+		return qerr.Config("kafka", "validate", errors.New("unsupported start_from"))
 	}
 	return nil
 }
@@ -222,23 +220,22 @@ func applyTuningDefaults(t *Tuning) {
 
 func validateTuning(t Tuning) error {
 	if t.InFlightBytes <= 0 {
-		return qerr.Config("kafka", "validate", stderrors.New("inflight_bytes must be positive"))
+		return qerr.Config("kafka", "validate", errors.New("inflight_bytes must be positive"))
 	}
 	if t.InFlightMsgs <= 0 {
-		return qerr.Config("kafka", "validate", stderrors.New("inflight_msgs must be positive"))
+		return qerr.Config("kafka", "validate", errors.New("inflight_msgs must be positive"))
 	}
 	if t.WindowBits < _minWindowBits {
-		return qerr.Config("kafka", "validate", stderrors.New("window_bits must be >= 256"))
+		return qerr.Config("kafka", "validate", errors.New("window_bits must be >= 256"))
 	}
 	if int64(t.WindowBits) < t.InFlightMsgs {
-		return qerr.Config("kafka", "validate",
-			fmt.Errorf("inflight_msgs (%d) must be <= window_bits (%d)", t.InFlightMsgs, t.WindowBits))
+		return qerr.Config("kafka", "validate", errors.New("inflight_msgs must be <= window_bits"))
 	}
 	if t.CommitInterval <= 0 {
-		return qerr.Config("kafka", "validate", stderrors.New("commit_interval must be positive"))
+		return qerr.Config("kafka", "validate", errors.New("commit_interval must be positive"))
 	}
 	if t.CommitStep == 0 {
-		return qerr.Config("kafka", "validate", stderrors.New("commit_step must be positive"))
+		return qerr.Config("kafka", "validate", errors.New("commit_step must be positive"))
 	}
 	return nil
 }

--- a/source/kafka/driver_sarama.go
+++ b/source/kafka/driver_sarama.go
@@ -37,12 +37,10 @@ func (d *SaramaDriver) Configure(ctx context.Context, cfg Config) error {
 	d.tuning = tun
 
 	if tun.WindowBits < _minWindowBits {
-		return qerr.Config("kafka", "validate",
-			fmt.Errorf("window_bits (%d) must be >= %d", tun.WindowBits, _minWindowBits))
+		return qerr.Config("kafka", "validate", errors.New("window_bits below minimum"))
 	}
 	if int64(tun.WindowBits) < tun.InFlightMsgs {
-		return qerr.Config("kafka", "validate",
-			fmt.Errorf("inflight_msgs (%d) must be <= window_bits (%d)", tun.InFlightMsgs, tun.WindowBits))
+		return qerr.Config("kafka", "validate", errors.New("inflight_msgs must be <= window_bits"))
 	}
 
 	d.baseAttrs = []slog.Attr{

--- a/source/kafka/driver_sarama_test.go
+++ b/source/kafka/driver_sarama_test.go
@@ -1,67 +1,286 @@
 package kafka
 
-import "testing"
+import (
+	"sync"
+	"testing"
+)
 
-func TestPartitionTrackerAdvance(t *testing.T) {
+func TestPartitionTracker_AckAdvance(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		windowBits  uint32
+		resetBase   int64
+		reserve     []int64
+		ackSequence []int64
+		wantBases   []int64
+		wantAdv     []bool
+	}{
+		{
+			name:        "in_order_advance",
+			windowBits:  8,
+			resetBase:   100,
+			reserve:     []int64{100, 101, 102},
+			ackSequence: []int64{100, 101, 102},
+			wantBases:   []int64{101, 102, 103},
+			wantAdv:     []bool{true, true, true},
+		},
+		{
+			name:        "out_of_order_blocks_until_base_acked",
+			windowBits:  8,
+			resetBase:   100,
+			reserve:     []int64{100, 101, 102},
+			ackSequence: []int64{101, 100},
+			wantBases:   []int64{100, 102},
+			wantAdv:     []bool{false, true},
+		},
+		{
+			name:        "ack_beyond_window_ignored",
+			windowBits:  4,
+			resetBase:   50,
+			reserve:     []int64{50},
+			ackSequence: []int64{80},
+			wantBases:   []int64{50},
+			wantAdv:     []bool{false},
+		},
+		{
+			name:        "ack_below_base_ignored",
+			windowBits:  8,
+			resetBase:   100,
+			reserve:     []int64{100},
+			ackSequence: []int64{99},
+			wantBases:   []int64{100},
+			wantAdv:     []bool{false},
+		},
+		{
+			name:        "duplicate_ack_no_double_advance",
+			windowBits:  8,
+			resetBase:   100,
+			reserve:     []int64{100},
+			ackSequence: []int64{100, 100},
+			wantBases:   []int64{101, 101},
+			wantAdv:     []bool{true, false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tracker := NewPartitionTracker(tt.windowBits)
+			tracker.Reset(tt.resetBase)
+
+			for _, off := range tt.reserve {
+				tracker.Reserve(off)
+			}
+
+			for i, off := range tt.ackSequence {
+				base, adv := tracker.AckOffset(off)
+				if base != tt.wantBases[i] {
+					t.Fatalf("AckOffset(%d)[%d]: base got %d, want %d", off, i, base, tt.wantBases[i])
+				}
+				if adv != tt.wantAdv[i] {
+					t.Fatalf("AckOffset(%d)[%d]: adv got %v, want %v", off, i, adv, tt.wantAdv[i])
+				}
+			}
+		})
+	}
+}
+
+func TestPartitionTracker_ReserveOverflow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		windowBits uint32
+		resetBase  int64
+		fill       int
+		overflow   int64
+		wantSlot   uint32
+	}{
+		{
+			name:       "within_window",
+			windowBits: 4,
+			resetBase:  10,
+			fill:       3,
+			overflow:   13,
+			wantSlot:   3,
+		},
+		{
+			name:       "at_boundary_returns_invalid",
+			windowBits: 4,
+			resetBase:  10,
+			fill:       4,
+			overflow:   14,
+			wantSlot:   InvalidSlot,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tracker := NewPartitionTracker(tt.windowBits)
+			tracker.Reset(tt.resetBase)
+
+			for i := 0; i < tt.fill; i++ {
+				tracker.Reserve(tt.resetBase + int64(i))
+			}
+
+			got := tracker.Reserve(tt.overflow)
+			if got != tt.wantSlot {
+				t.Fatalf("Reserve(%d): got %d, want %d", tt.overflow, got, tt.wantSlot)
+			}
+		})
+	}
+}
+
+func TestPartitionTracker_AutoInitOnReserve(t *testing.T) {
+	t.Parallel()
+
 	tracker := NewPartitionTracker(8)
-	tracker.Reset(100)
 
-	tracker.Reserve(100)
-	tracker.Reserve(101)
-	tracker.Reserve(102)
-
-	if _, advanced := tracker.AckOffset(101); advanced {
-		t.Fatalf("ack out of order should not advance base")
+	if tracker.Initialized() {
+		t.Fatal("should not be initialized before first Reserve")
 	}
 
-	if base, advanced := tracker.AckOffset(100); !advanced || base != 102 {
-		t.Fatalf("expected base 102 after acking offset 100, got base=%d advanced=%v", base, advanced)
+	slot := tracker.Reserve(42)
+	if slot != 0 {
+		t.Fatalf("first Reserve should return slot 0, got %d", slot)
 	}
-
-	if base, advanced := tracker.AckOffset(102); !advanced || base != 103 {
-		t.Fatalf("expected base 103 after acking remaining slots, got base=%d advanced=%v", base, advanced)
+	if !tracker.Initialized() {
+		t.Fatal("should be initialized after first Reserve")
+	}
+	if tracker.Base() != 42 {
+		t.Fatalf("base should be 42 after first Reserve, got %d", tracker.Base())
 	}
 }
 
-func TestPartitionTrackerOverflow(t *testing.T) {
-	tracker := NewPartitionTracker(4)
-	tracker.Reset(10)
-	for i := int64(10); i < 14; i++ {
-		if slot := tracker.Reserve(i); slot == InvalidSlot {
-			t.Fatalf("unexpected overflow for offset %d", i)
-		}
+func TestPartitionTracker_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	tracker := NewPartitionTracker(4096)
+	tracker.Reset(0)
+
+	const workers = 8
+	const opsPerWorker = 500
+
+	var wg sync.WaitGroup
+	wg.Add(workers * 2)
+
+	for w := 0; w < workers; w++ {
+		go func(base int) {
+			defer wg.Done()
+			for i := 0; i < opsPerWorker; i++ {
+				tracker.Reserve(int64(base*opsPerWorker + i))
+			}
+		}(w)
 	}
-	if slot := tracker.Reserve(14); slot != InvalidSlot {
-		t.Fatalf("expected overflow sentinel, got %d", slot)
+
+	for w := 0; w < workers; w++ {
+		go func(base int) {
+			defer wg.Done()
+			for i := 0; i < opsPerWorker; i++ {
+				tracker.AckOffset(int64(base*opsPerWorker + i))
+			}
+		}(w)
 	}
-	if base := tracker.Base(); base != 10 {
-		t.Fatalf("base should remain unchanged on overflow, got %d", base)
+
+	wg.Wait()
+
+	base := tracker.Base()
+	if base < 0 {
+		t.Fatalf("base should be non-negative after operations, got %d", base)
 	}
 }
 
-func TestPartitionTrackerAckOutOfWindow(t *testing.T) {
-	tracker := NewPartitionTracker(4)
-	tracker.Reset(50)
-	tracker.Reserve(50)
-	if base, advanced := tracker.AckOffset(80); advanced || base != 50 {
-		t.Fatalf("out-of-window ack should be ignored, base=%d advanced=%v", base, advanced)
+func TestOffsetTracker_TrackAndAck(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		trackOff   int64
+		trackBytes int64
+		ackOff     int64
+		wantOK     bool
+	}{
+		{
+			name:       "ack_tracked_offset",
+			trackOff:   10,
+			trackBytes: 42,
+			ackOff:     10,
+			wantOK:     true,
+		},
+		{
+			name:       "ack_untracked_offset",
+			trackOff:   10,
+			trackBytes: 42,
+			ackOff:     99,
+			wantOK:     false,
+		},
+		{
+			name:       "double_ack_second_returns_false",
+			trackOff:   10,
+			trackBytes: 42,
+			ackOff:     10,
+			wantOK:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ot := NewOffsetTracker(4)
+			handle := AckHandle{offset: tt.trackOff, bytes: tt.trackBytes}
+			ot.Track(tt.trackOff, handle)
+
+			h, ok := ot.Ack(tt.ackOff)
+			if ok != tt.wantOK {
+				t.Fatalf("Ack(%d): ok got %v, want %v", tt.ackOff, ok, tt.wantOK)
+			}
+			if ok {
+				if h.offset != tt.trackOff || h.bytes != tt.trackBytes {
+					t.Fatalf("handle: got %+v, want offset=%d bytes=%d", h, tt.trackOff, tt.trackBytes)
+				}
+
+				_, ok2 := ot.Ack(tt.ackOff)
+				if ok2 {
+					t.Fatal("second Ack should return false")
+				}
+			}
+		})
 	}
 }
 
-func TestAckerTrackAck(t *testing.T) {
-	ackr := NewOffsetTracker(4)
-	handle := AckHandle{offset: 10, bytes: 42}
-	ackr.Track(10, handle)
+func TestOffsetTracker_ClosePreventsTracking(t *testing.T) {
+	t.Parallel()
 
-	h, ok := ackr.Ack(10)
-	if !ok {
-		t.Fatalf("expected ack handle")
-	}
-	if h.offset != handle.offset || h.bytes != handle.bytes {
-		t.Fatalf("unexpected handle values: got %+v want %+v", h, handle)
-	}
+	ot := NewOffsetTracker(4)
+	ot.Track(1, AckHandle{offset: 1, bytes: 10})
+	ot.Close()
 
-	if _, ok := ackr.Ack(10); ok {
-		t.Fatalf("ack should have been removed after first Ack")
+	ot2 := NewOffsetTracker(4)
+	ot2.Close()
+	ot2.Track(2, AckHandle{offset: 2, bytes: 20})
+	if ot2.Size() != 0 {
+		t.Fatalf("Size after close+track: got %d, want 0", ot2.Size())
+	}
+}
+
+func TestOffsetTracker_ResetReturnsPending(t *testing.T) {
+	t.Parallel()
+
+	ot := NewOffsetTracker(4)
+	ot.Track(10, AckHandle{offset: 10, bytes: 100})
+	ot.Track(11, AckHandle{offset: 11, bytes: 200})
+
+	handles := ot.Reset()
+	if len(handles) != 2 {
+		t.Fatalf("Reset: got %d handles, want 2", len(handles))
+	}
+	if ot.Size() != 0 {
+		t.Fatalf("Size after Reset: got %d, want 0", ot.Size())
 	}
 }

--- a/source/kafka/partition_processor.go
+++ b/source/kafka/partition_processor.go
@@ -155,12 +155,12 @@ func (pp *partitionProcessor) Shutdown() {
 	close(pp.stopCh)
 	pp.wg.Wait()
 
-	_ = pp.checkpointMgr.Reset()
-
 	if pp.checkpointMgr.Initialized() {
 		base := pp.checkpointMgr.Base()
 		if base >= 0 && pp.commitStrategy != nil {
-			pp.commitStrategy.MarkAndCommit(pp.session, pp.topic, pp.partition, base)
+			pp.commitStrategy.Flush(pp.session, pp.topic, pp.partition, base)
 		}
 	}
+
+	_ = pp.checkpointMgr.Reset()
 }

--- a/source/kafka/register_source.go
+++ b/source/kafka/register_source.go
@@ -2,7 +2,7 @@ package kafka
 
 import (
 	"context"
-	"errors"
+	"fmt"
 
 	pb "quanta/api/proto/v1"
 	qerr "quanta/internal/errors"
@@ -32,7 +32,7 @@ var _ source.Adapter = (*sourceAdapter)(nil)
 func (a *sourceAdapter) Configure(ctx context.Context, cfg any) error {
 	kc, ok := cfg.(*Config)
 	if !ok {
-		return qerr.Config("kafka", "configure", errors.New("unexpected config type"))
+		return qerr.Config("kafka", "configure", fmt.Errorf("unexpected config type %T", cfg))
 	}
 	return a.driver.Configure(ctx, *kc)
 }

--- a/source/kafka/register_source.go
+++ b/source/kafka/register_source.go
@@ -2,7 +2,7 @@ package kafka
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	pb "quanta/api/proto/v1"
 	qerr "quanta/internal/errors"
@@ -32,7 +32,7 @@ var _ source.Adapter = (*sourceAdapter)(nil)
 func (a *sourceAdapter) Configure(ctx context.Context, cfg any) error {
 	kc, ok := cfg.(*Config)
 	if !ok {
-		return qerr.Config("kafka", "configure", fmt.Errorf("expected *kafka.Config, got %T", cfg))
+		return qerr.Config("kafka", "configure", errors.New("unexpected config type"))
 	}
 	return a.driver.Configure(ctx, *kc)
 }

--- a/source/kafka/registry.go
+++ b/source/kafka/registry.go
@@ -1,7 +1,7 @@
 package kafka
 
 import (
-	"fmt"
+	"errors"
 
 	qerr "quanta/internal/errors"
 )
@@ -31,7 +31,7 @@ func Lookup(name string) (Registration, bool) {
 func NewAdapter(name string) (Adapter, error) {
 	reg, ok := _registry[name]
 	if !ok {
-		return nil, qerr.Source("kafka", "create", fmt.Errorf("unsupported driver %q", name))
+		return nil, qerr.Source("kafka", "create", errors.New("unsupported driver"))
 	}
 	return reg.New(), nil
 }

--- a/source/kafka/registry.go
+++ b/source/kafka/registry.go
@@ -1,7 +1,7 @@
 package kafka
 
 import (
-	"errors"
+	"fmt"
 
 	qerr "quanta/internal/errors"
 )
@@ -31,7 +31,7 @@ func Lookup(name string) (Registration, bool) {
 func NewAdapter(name string) (Adapter, error) {
 	reg, ok := _registry[name]
 	if !ok {
-		return nil, qerr.Source("kafka", "create", errors.New("unsupported driver"))
+		return nil, qerr.Source("kafka", "create", fmt.Errorf("unsupported driver %q", name))
 	}
 	return reg.New(), nil
 }


### PR DESCRIPTION

## Summary

Introduces the `AckCoordinator`, a centralized checkpoint commit authority that replaces the scattered ack pattern. The coordinator uses a [kref-inspired](https://www.kernel.org/doc/Documentation/kref.txt) refcounted barrier to ensure checkpoints are committed **only** after every sink has acknowledged every derived frame. This PR also converts the Kafka sink to a truly asynchronous `AckAware` model, fixes dangling barriers in the S3 sink, and updates all spec documents.

## Motivation

The previous ack architecture had several fundamental design flaws:

1. **Scattered ack placement** — ack callbacks were invoked at multiple points (runner, sinks), making it impossible to reason about exactly-once commit semantics
2. **Double-ack in AckAware sinks** — both the runner and the sink could ack the same checkpoint
3. **Fan-out sharing a single CheckpointToken** — when a transformer produces N output frames, the checkpoint was acked N times instead of once
4. **Zero frame linkage in error paths** — `errors.Join` lost the association between frames and their checkpoints

## Design

### AckCoordinator

Inspired by the Linux kernel's `kref` refcounting pattern and Kafka's group-coordinator protocol:

- **Barrier** — a refcounted completion token per source frame. Reference count = `len(derivedFrames) × ackAwareSinks + 1` (for sync sinks)
- **Tri-state CAS** — `Live → Committed` or `Live → Aborted`. A single `CompareAndSwap` arbitrates the race between `release()` and `Abort()`
- **Pointer-safe removal** — `removeBarrier` compares pointer identity before deleting, preventing successor clobber
- **Nil token guards** — nil checkpoints produce valid barriers that are not tracked in the map
- **Duplicate key detection** — source redelivery force-aborts stale barriers
- **Underflow warning** — `slog.Warn` on refcount going below zero
- **Observability** — `Len()` reports outstanding unresolved barriers

### Barrier State Machine

```mermaid
stateDiagram-v2
  [*] --> Live : Barrier(tok, refs)
  Live --> Committed : refs ≤ 0 (CAS succeeds)
  Live --> Aborted : Abort() CAS succeeds
  Committed --> [*] : commit(tok) → source
  Aborted --> [*] : removeBarrier (no commit)
```

### Data Flow

```mermaid
flowchart LR
  src["Source"] --> run["Runner"]
  run -- "Barrier(tok, refs)" --> coord["AckCoordinator"]
  run --> snk_k["Kafka Sink\n(AckAware)"]
  run --> snk_s3["S3 Sink\n(AckAware)"]
  run -.-> snk_out["Stdout\n(sync)"]

  snk_k -- "Ack(tok)" --> coord
  snk_s3 -- "Ack(tok)" --> coord
  snk_out -- "Complete()" --> coord

  coord -- "commit" --> src
```


## Testing

### Unit Tests

- **29 pipeline tests** (coordinator + runner) — all pass with `-race`
- **12 Kafka sink tests** — all pass with `-race` and `goleak`
- Key test coverage:
  - Barrier lifecycle: complete, abort, concurrent release (100 goroutines)
  - Edge cases: nil tokens, duplicate barriers, refcount underflow, pointer-safe removal
  - Kafka sink: publish enqueue, pump ack on success/error, drain inflight, close waits pump
  - S3 sink: ackAll on success and failure paths

### Docker E2E

Verified twice with full Docker stack (Confluent Kafka 7.9.0 KRaft + LocalStack S3 + CloudEvents transformer):

| Scenario           | Messages        | Consumer Lag | Errors |
| ------------------ | --------------- | ------------ | ------ |
| Kafka to Kafka      | 3000 / 2700     | 0/0/0        | 0      |
| Kafka to S3 (JSONL) | 2200–2700 lines | 0            | 0      |

---

**Stats:** 30 files changed, ~2900 insertions, ~420 deletions
